### PR TITLE
Add screenshot support for desktop version

### DIFF
--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -113,6 +113,14 @@ public class FreeJ2ME
 		{
 			public void keyPressed(KeyEvent e)
 			{
+				if(config.isRunning)
+				{
+					config.keyPressed(getMobileKey(e.getKeyCode()));
+				}
+				else
+				{
+					Mobile.getPlatform().keyPressed(getMobileKey(e.getKeyCode()));
+				}
 				switch(e.getKeyCode())
 				{
 					case KeyEvent.VK_PLUS:
@@ -127,15 +135,10 @@ public class FreeJ2ME
 							scaleFactor--;
 							main.setSize(lcdWidth * scaleFactor + xborder, lcdHeight * scaleFactor + yborder);
 						}
-					break;	
-				}
-				if(config.isRunning)
-				{
-					config.keyPressed(getMobileKey(e.getKeyCode()));
-				}
-				else
-				{
-					Mobile.getPlatform().keyPressed(getMobileKey(e.getKeyCode()));
+					break;
+					case KeyEvent.VK_C:
+						ScreenShot.takeScreenshot(false);
+					break;
 				}
 			}
 

--- a/src/org/recompile/freej2me/RetroPie.java
+++ b/src/org/recompile/freej2me/RetroPie.java
@@ -248,7 +248,7 @@ public class RetroPie
 				// ESC - Quit
 				case 0x1B: System.exit(0);
 
-				case 112: ScreenShot.takeScreenshot();
+				case 112: ScreenShot.takeScreenshot(true);
 
 				/*
 				case : return Mobile.GAME_UP;

--- a/src/org/recompile/freej2me/ScreenShot.java
+++ b/src/org/recompile/freej2me/ScreenShot.java
@@ -24,17 +24,40 @@ import javax.imageio.ImageIO;
 import java.lang.Exception;
 import java.util.Date;
 import java.text.SimpleDateFormat;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
 
 public class ScreenShot
 {
-	public static void takeScreenshot()
+	public static void takeScreenshot(boolean saveToHomeDir)
 	{
 		try
 		{
 			Date date = new Date();
+			String fileName;
 			SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
-			String fileName = System.getProperty("user.home") + "/Pictures/Screenshot from "
-							+ dateFormat.format(date) + ".png";
+
+			if (saveToHomeDir == true)
+			{
+				fileName = System.getProperty("user.home") + "/Pictures/Screenshot from " +
+							dateFormat.format(date) + ".png";
+			}
+			else
+			{
+				String screenshotPath = Mobile.getPlatform().dataPath + "screenshots";
+				try
+				{
+					Files.createDirectories(Paths.get(screenshotPath));
+				}
+				catch (Exception e)
+				{
+					System.out.println("Problem Creating Screenshot Path "+ screenshotPath);
+					System.out.println(e.getMessage());
+				}
+				fileName = screenshotPath + "/Screenshot from " + 
+							dateFormat.format(date) + ".png";
+			}
 
 			File outputfile = new File(fileName);
 			ImageIO.write(Mobile.getPlatform().getLCD(), "png", outputfile);


### PR DESCRIPTION
I modified the screenshot routine so that:
 - It keeps it's exact same behavior for RetroPie users.
 - For desktop version users, it creates a "screenshots" directory along the "rms" and "config" ones, and stores the screenshots there.

I bound it to the "C" key. Change it to whatever you feel convenient.