### PR TITLE
Implement Nokia Middle button keycode

### DIFF
--- a/src/javax/microedition/lcdui/Canvas.java
+++ b/src/javax/microedition/lcdui/Canvas.java
@@ -73,6 +73,7 @@ public abstract class Canvas extends Displayable
 			case Mobile.NOKIA_DOWN: return DOWN;
 			case Mobile.NOKIA_LEFT: return LEFT;
 			case Mobile.NOKIA_RIGHT: return RIGHT;
+			case Mobile.NOKIA_SOFT3: return FIRE;
 		}
 		return 0;
 	}
@@ -85,17 +86,18 @@ public abstract class Canvas extends Displayable
 			//case Mobile.GAME_DOWN: return Mobile.KEY_NUM8;
 			//case Mobile.GAME_LEFT: return Mobile.KEY_NUM4;
 			//case Mobile.GAME_RIGHT: return Mobile.KEY_NUM6;
+			//case Mobile.GAME_FIRE: return Mobile.KEY_NUM5;
 			case Mobile.GAME_UP: return Mobile.NOKIA_UP;
 			case Mobile.GAME_DOWN: return Mobile.NOKIA_DOWN;
 			case Mobile.GAME_LEFT: return Mobile.NOKIA_LEFT;
 			case Mobile.GAME_RIGHT: return Mobile.NOKIA_RIGHT;
-			case Mobile.GAME_FIRE: return Mobile.KEY_NUM5;
+			case Mobile.GAME_FIRE: return Mobile.NOKIA_SOFT3;
 			case Mobile.GAME_A: return Mobile.KEY_NUM1;
 			case Mobile.GAME_B: return Mobile.KEY_NUM3;
 			case Mobile.GAME_C: return Mobile.KEY_NUM7;
 			case Mobile.GAME_D: return Mobile.KEY_NUM9;
 		}
-		return Mobile.KEY_NUM5;
+		return Mobile.NOKIA_SOFT3;
 	}
 
 	public String getKeyName(int keyCode)

--- a/src/javax/microedition/lcdui/Form.java
+++ b/src/javax/microedition/lcdui/Form.java
@@ -96,6 +96,7 @@ public class Form extends Screen
 			case Mobile.NOKIA_DOWN: currentItem++; break;
 			case Mobile.NOKIA_SOFT1: doLeftCommand(); break;
 			case Mobile.NOKIA_SOFT2: doRightCommand(); break;
+			case Mobile.NOKIA_SOFT3: doDefaultCommand(); break;
 			case Mobile.KEY_NUM5: doDefaultCommand(); break;
 		}
 		if (currentItem>=items.size()) { currentItem=0; }

--- a/src/javax/microedition/lcdui/List.java
+++ b/src/javax/microedition/lcdui/List.java
@@ -185,6 +185,7 @@ public class List extends Screen implements Choice
 			case Mobile.NOKIA_DOWN: currentItem++; break;
 			case Mobile.NOKIA_SOFT1: doLeftCommand(); break;
 			case Mobile.NOKIA_SOFT2: doRightCommand(); break;
+			case Mobile.NOKIA_SOFT3: doDefaultCommand(); break;
 			case Mobile.KEY_NUM5: doDefaultCommand(); break;
 		}
 		if (currentItem>=items.size()) { currentItem=0; }

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -217,6 +217,7 @@ public class Config
 						case Mobile.NOKIA_UP: itemid--; break;
 						case Mobile.NOKIA_DOWN: itemid++; break;
 						case Mobile.NOKIA_SOFT1: menuid=0; break;
+						case Mobile.NOKIA_SOFT3: doMenuAction(); break;
 					}
 				}
 				if(settings.get("phone").equals("Siemens"))

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -266,6 +266,7 @@ public class FreeJ2ME
 				case KeyEvent.VK_DOWN: return Mobile.NOKIA_DOWN;
 				case KeyEvent.VK_LEFT: return Mobile.NOKIA_LEFT;
 				case KeyEvent.VK_RIGHT: return Mobile.NOKIA_RIGHT;
+				case KeyEvent.VK_ENTER: return Mobile.NOKIA_SOFT3;
 			}
 		}
 

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -340,6 +340,7 @@ public class Libretro
 				case 274: return Mobile.NOKIA_DOWN; // Down
 				case 276: return Mobile.NOKIA_LEFT; // Left
 				case 275: return Mobile.NOKIA_RIGHT; // Right
+				case 13: return Mobile.NOKIA_SOFT3; // Middle
 			}
 		}
 		if(useSiemensControls)


### PR DESCRIPTION
This implements the _Nokia Middle button_ softkey:
```
KEY_SOFTKEY3

public static final int KEY_SOFTKEY3
Key code constant for select key, middle softkey or second command button key. Not all devices have this key. The value is -5. 
```
for games that depend on it.
And modifies some other parts of FreeJ2ME to fully integrate the softkey.

WARNING / NOTE:
I modified javax.microedition.lcdui.Canvas replacing KEY_NUM5 with NOKIA_SOFT3. I'm not pretty sure of the correctness of this modification at all. I'm not sure what the behavior should be when phone is set to Nokia or Standard, since they appear to be harcoded to Nokia. :confused: . Shouldn't they be config-dependent? 
