### PR TITLE
Fixed some issues in Munkiki's Castles emulation

### DIFF
--- a/src/com/nokia/mid/m3d/M3D.java
+++ b/src/com/nokia/mid/m3d/M3D.java
@@ -485,15 +485,29 @@ public class M3D
 		}
 	}
 
-	public void drawArrays(int a, int b, int c)  // called after clear -- background?
+	// Call order:
+	// vertexPointerub(3, 0, [ -100, 20, -100, 0, -20, 0, 100, 20, -100, ]); // 3, 0, len 9
+	// drawArrays(4, 0, 3);
+	//
+	// Water is a huge triangle with one point under the player. Other 2 (far) points form the horizon.
+	// We'll cheat here. Instead of drawing 3D surface let's calculate Y coordinate (on screen) of far point.
+	// And then fill everything below it with a color.
+	public void drawArrays(int a, int b, int c)
 	{
-		// The expected result.  No idea how to get there from here:
-		//vertexPointerub(3, 0, [ -100, 20, -100, 0, -20, 0, 100, 20, -100, ]); // 3, 0, len 9
-		//drawArrays(4, 0, 3);
 		//System.out.println("drawArrays("+a+", "+b+", "+c+")");
 		gc.setColor(color);
-		gc.fillRect(0,20, width, height);
+		applyMatrix(matrix);
 
+		// projection
+		double y, z;
+		y = verts[1];
+		z = verts[2];
+		y = y*projm[5]/(-z);
+		double oy = height/2;
+		y = (y*oy)+oy;
+
+		//System.out.println("y: "+y);
+		gc.fillRect(0, (int)y, width, height - (int)y);
 	}
 
 	public void bindTexture(int a, Texture b)

--- a/src/com/nokia/mid/m3d/M3D.java
+++ b/src/com/nokia/mid/m3d/M3D.java
@@ -161,39 +161,41 @@ public class M3D
 		matmul(tempt, matrix);
 		clone(matrix, tempt);
 	}
-
-	public void rotatexi(int Y, int Z, int X, int W) // probably not a quaternion 
+	
+	public void rotatexi(int Angle, int X, int Y, int Z)
 	{
-		//System.out.println("rotatexi("+Y+", "+Z+", "+X+", "+W+");");
-		// 1 degree = 0.0174533 rad
-		// from d:1343 rotatexi(1310720, 65536, 0, 0);
-		// from d:1347 rotatexi(c0, 65536, 0, 0);
-		// from d:1354 rotatexi(cx * 90, 0, 65536, 0);
+		double a = (Angle/65536.0)*0.0174533;
 
-		double x = (X/65536.0)*0.0174533;
-		double y = ((Y/65536.0)-10)*0.0174533;
-		double z = (Z/65536.0)*0.0174533;
-
-		// rotate on y
-		tempr[0]  =  Math.cos(y); tempr[1]  =  0; tempr[2]  = -Math.sin(y); tempr[3]  =  0;
-		tempr[4]  =  0;           tempr[5]  =  1; tempr[6]  =  0;           tempr[7]  =  0;
-		tempr[8]  =  Math.sin(y); tempr[9]  =  0; tempr[10] =  Math.cos(y); tempr[11] =  0;
-		tempr[12] =  0;           tempr[13] =  0; tempr[14] =  0;           tempr[15] =  1;
-		clone(rotm, tempr);
-
-		// rotate on x
-		tempr[0]  =  1; tempr[1]  =  0;            tempr[2]  =  0;           tempr[3]  =  0;
-		tempr[4]  =  0; tempr[5]  =  Math.cos(x);  tempr[6]  =  Math.sin(x); tempr[7]  =  0;
-		tempr[8]  =  0; tempr[9]  = -Math.sin(x);  tempr[10] =  Math.cos(x); tempr[11] =  0;
-		tempr[12] =  0; tempr[13] =  0;            tempr[14] =  0;           tempr[15] =  1;
-		matmul(rotm, tempr);
-
-		// rotate on z
-		tempr[0]  =  Math.cos(z); tempr[1]  =  Math.sin(z); tempr[2]  =  0; tempr[3]  =  0;
-		tempr[4]  = -Math.sin(z); tempr[5]  =  Math.cos(z); tempr[6]  =  0; tempr[7]  =  0;
-		tempr[8]  =  0;           tempr[9]  =  0;           tempr[10] =  1; tempr[11] =  0;
-		tempr[12] =  0;           tempr[13] =  0;           tempr[14] =  0; tempr[15] =  1;
-		matmul(rotm, tempr);
+		// (X, Y, Z) define an axis for rotation
+		// But game uses only X, Y or Z axis
+		// Following code is enough for game to run without issues
+		if(X != 0)
+		{
+			// rotate on x
+			tempr[0]  =  1; tempr[1]  =  0;            tempr[2]  =  0;           tempr[3]  =  0;
+			tempr[4]  =  0; tempr[5]  =  Math.cos(a);  tempr[6]  =  Math.sin(a); tempr[7]  =  0;
+			tempr[8]  =  0; tempr[9]  = -Math.sin(a);  tempr[10] =  Math.cos(a); tempr[11] =  0;
+			tempr[12] =  0; tempr[13] =  0;            tempr[14] =  0;           tempr[15] =  1;
+			clone(rotm, tempr);
+		}
+		if(Y != 0)
+		{
+			// rotate on y
+			tempr[0]  =  Math.cos(a); tempr[1]  =  0; tempr[2]  = -Math.sin(a); tempr[3]  =  0;
+			tempr[4]  =  0;           tempr[5]  =  1; tempr[6]  =  0;           tempr[7]  =  0;
+			tempr[8]  =  Math.sin(a); tempr[9]  =  0; tempr[10] =  Math.cos(a); tempr[11] =  0;
+			tempr[12] =  0;           tempr[13] =  0; tempr[14] =  0;           tempr[15] =  1;
+			clone(rotm, tempr);
+		}
+		if(Z != 0)
+		{
+			// rotate on z
+			tempr[0]  =  Math.cos(a); tempr[1]  =  Math.sin(a); tempr[2]  =  0; tempr[3]  =  0;
+			tempr[4]  = -Math.sin(a); tempr[5]  =  Math.cos(a); tempr[6]  =  0; tempr[7]  =  0;
+			tempr[8]  =  0;           tempr[9]  =  0;           tempr[10] =  1; tempr[11] =  0;
+			tempr[12] =  0;           tempr[13] =  0;           tempr[14] =  0; tempr[15] =  1;
+			clone(rotm, tempr);
+		}
 
 		matmul(rotm, matrix);
 		clone(matrix, rotm);

--- a/src/com/nokia/mid/m3d/M3D.java
+++ b/src/com/nokia/mid/m3d/M3D.java
@@ -118,19 +118,19 @@ public class M3D
 
 	public void frustumxi(int left, int right, int top, int bottom, int nearclip, int farclip) //-3,3, -2,2, 3,1000
 	{
-		//System.out.println("frustrumxi("+a+", "+b+", "+c+", "+d+", "+near+", "+far+");");
-		// c.c: bu.frustumxi(-bp << 11, bp << 11, -bo << 11, bo << 11, 196608, 65536000);
-		double r = right/2048;
-		double l = left/2048;
-		double t = top/2048;
-		double b = bottom/2048;
+		//System.out.println("frustrumxi("+left+", "+right+", "+top+", "+bottom+", "+nearclip+", "+farclip+");");
 
-		double n = nearclip/655360;
-		double f = farclip/655360;
+		double r = right/65536.0;
+		double l = left/65536.0;
+		double t = top/65536.0;
+		double b = bottom/65536.0;
+
+		double n = nearclip/65536.0;
+		double f = farclip/65536.0;
 		
-		near = -0.01;//25;//-n;
+		near = -n;
 		far = -f;
-		projection(projm, r-l, b-t, 90, near, far);
+		projection(projm, r-l, t-b, n, f);
 	}
 
 	public void scalexi(int X, int Y, int Z)
@@ -506,19 +506,17 @@ public class M3D
 		m[12] = 0; m[13] = 0; m[14] = 0; m[15] = 1;
 	}
 
-	private void projection(double[] m, double w, double h, double fov, double near, double far)
+	private void projection(double[] m, double w, double h, double n, double f)
 	{
-		fov = fov * 0.0174533;
-		double sx = 1/Math.tan(fov/2);
-		double sy = -sx*(w/h);
-		double sz = (far / (far-near)); // 1 > z > -1
-		double d  =  -1.0;
-		double e  =  1;
+		//System.out.println("projection("+w+", "+h+", "+n+", "+f+");");
+		double d = -(f+n)/(f-n);
+		double e = -(2*f*n)/(f-n);
 
-		m[0]  = sx;  m[1]  = 0;  m[2]  = 0;  m[3]  = 0;
-		m[4]  = 0;   m[5]  =sy;  m[6]  = 0;  m[7]  = 0;
-		m[8]  = 0;   m[9]  = 0;  m[10] =sz;  m[11] = d;
-		m[12] = 0;   m[13] = 0;  m[14] = e;  m[15] = 0;
+
+		m[0]  = 2*n/w; m[1]  = 0;      m[2]  = 0;  m[3]  = 0;
+		m[4]  = 0;     m[5]  = 2*n/h;  m[6]  = 0;  m[7]  = 0;
+		m[8]  = 0;     m[9]  = 0;      m[10] = d;  m[11] = -1;
+		m[12] = 0;     m[13] = 0;      m[14] = e;  m[15] = 0;
 	}
 
 	private void clone(double[] m1, double[] m2)

--- a/src/com/nokia/mid/m3d/M3D.java
+++ b/src/com/nokia/mid/m3d/M3D.java
@@ -113,6 +113,7 @@ public class M3D
 
 	public void loadIdentity()
 	{
+		//System.out.println("loadIdentity");
 		identity(matrix);
 	}
 
@@ -127,6 +128,8 @@ public class M3D
 
 		double n = nearclip/65536.0;
 		double f = farclip/65536.0;
+
+		//System.out.println("frustrumxi("+l+", "+r+", "+t+", "+b+", "+n+", "+f+");");
 		
 		near = -n;
 		far = -f;
@@ -135,9 +138,12 @@ public class M3D
 
 	public void scalexi(int X, int Y, int Z)
 	{
+		//System.out.println("scalexi("+X+", "+Y+", "+Z+");");
 		double x = (X/65536.0);
 		double y = (Y/65536.0);
 		double z = (Z/65536.0);
+		
+		//System.out.println("scalexi("+x+", "+y+", "+z+");");
 
 		temps[0]  = x; temps[1]  = 0; temps[2]  = 0; temps[3]  = 0;
 		temps[4]  = 0; temps[5]  = y; temps[6]  = 0; temps[7]  = 0;
@@ -150,9 +156,13 @@ public class M3D
 
 	public void translatexi(int X, int Y, int Z)
 	{
+		//System.out.println("translatexi("+X+", "+Y+", "+Z+");");
 		double x = (X/65536.0);
 		double y = (Y/65536.0);
 		double z = (Z/65536.0);
+		
+		//System.out.println("translatexi("+x+", "+y+", "+z+");");
+
 		tempt[0]  = 1; tempt[1]  = 0; tempt[2]  = 0; tempt[3]  = 0;
 		tempt[4]  = 0; tempt[5]  = 1; tempt[6]  = 0; tempt[7]  = 0;
 		tempt[8]  = 0; tempt[9]  = 0; tempt[10] = 1; tempt[11] = 0;
@@ -164,6 +174,7 @@ public class M3D
 	
 	public void rotatexi(int Angle, int X, int Y, int Z)
 	{
+		//System.out.println("rotatexi("+Angle+", "+X+", "+Y+", "+Z+");");
 		double a = (Angle/65536.0)*0.0174533;
 
 		// (X, Y, Z) define an axis for rotation
@@ -172,6 +183,9 @@ public class M3D
 		if(X != 0)
 		{
 			// rotate on x
+
+			//System.out.println("rotatexi( X: "+Angle/65536+");");
+
 			tempr[0]  =  1; tempr[1]  =  0;            tempr[2]  =  0;           tempr[3]  =  0;
 			tempr[4]  =  0; tempr[5]  =  Math.cos(a);  tempr[6]  =  Math.sin(a); tempr[7]  =  0;
 			tempr[8]  =  0; tempr[9]  = -Math.sin(a);  tempr[10] =  Math.cos(a); tempr[11] =  0;
@@ -181,6 +195,9 @@ public class M3D
 		if(Y != 0)
 		{
 			// rotate on y
+
+			//System.out.println("rotatexi( Y: "+Angle/65536+");");
+
 			tempr[0]  =  Math.cos(a); tempr[1]  =  0; tempr[2]  = -Math.sin(a); tempr[3]  =  0;
 			tempr[4]  =  0;           tempr[5]  =  1; tempr[6]  =  0;           tempr[7]  =  0;
 			tempr[8]  =  Math.sin(a); tempr[9]  =  0; tempr[10] =  Math.cos(a); tempr[11] =  0;
@@ -190,6 +207,9 @@ public class M3D
 		if(Z != 0)
 		{
 			// rotate on z
+
+			//System.out.println("rotatexi( Z: "+Angle/65536+");");
+
 			tempr[0]  =  Math.cos(a); tempr[1]  =  Math.sin(a); tempr[2]  =  0; tempr[3]  =  0;
 			tempr[4]  = -Math.sin(a); tempr[5]  =  Math.cos(a); tempr[6]  =  0; tempr[7]  =  0;
 			tempr[8]  =  0;           tempr[9]  =  0;           tempr[10] =  1; tempr[11] =  0;
@@ -203,11 +223,13 @@ public class M3D
 
 	public void pushMatrix() // game doesn't seem to push more than one thing at a time
 	{ 
+		//System.out.println("pushMatrix()");
 		clone(stack, matrix);
 	}
 
 	public void popMatrix()
 	{
+		//System.out.println("popMatrix()");
 		clone(matrix, stack);
 	}
 
@@ -223,6 +245,7 @@ public class M3D
 
 	public void vertexPointerub(int a, int b, byte[] vertices) 
 	{
+		//System.out.println("vertexPointerub("+a+", "+b+")");
 		int i=0;
 		for(i=0; i<vertices.length; i+=3)
 		{
@@ -352,6 +375,7 @@ public class M3D
 
 	public void drawElementsub(int A, int B, byte[] facelist)
 	{
+		//System.out.println("drawElementsub("+A+", "+B+")");
 		byte a, b;
 		double x1, y1, z1, x2, y2, z2, x3, y3, z3, w1;
 		double u1,v1, u2,v2, u3,v3;
@@ -466,6 +490,7 @@ public class M3D
 		// The expected result.  No idea how to get there from here:
 		//vertexPointerub(3, 0, [ -100, 20, -100, 0, -20, 0, 100, 20, -100, ]); // 3, 0, len 9
 		//drawArrays(4, 0, 3);
+		//System.out.println("drawArrays("+a+", "+b+", "+c+")");
 		gc.setColor(color);
 		gc.fillRect(0,20, width, height);
 
@@ -592,6 +617,7 @@ public class M3D
 
 	private void applyMatrix(double[] m)
 	{
+		//System.out.println("applyMatrix()");
 		double x, y, z, w;
 		for(int i=0; i<vertCount; i+=3)
 		{	


### PR DESCRIPTION
1) Rewrote rotation matrix method. It is now possible to rotate around X axis. And Z axis, but it's never used in game. This patch fixed an issue when you can't look up or down in "look around" mode.
2) Rewrote projection matrix method. Nothing noticeable happen. I believe it's closer to "real" implementation now.
3) Fixed water draw method. It's hacky but looks like real one.

New issues:
1) When in "look around" mode turn all the way to the left (or right). Now turn up and down. You should notice a slight translation. It still can be a game bug.
2) Polygon clip algorithm has a minor issue. It clips some triangles which it shouldn't.