### PR TITLE
Publish build artifacts with Github Actions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull-request]
 
 jobs:
   build:
@@ -8,10 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml
+    - name: Compute commit short SHA
+      id: shortsha
+      run: echo "::set-output name=value::$(git rev-parse --short HEAD)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: freej2me-${{ steps.shortsha.outputs.value }}
+        path: build/freej2me.jar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # freej2me
+
+![Java CI](https://github.com/hex007/freej2me/workflows/Java%20CI/badge.svg)
+
 A free J2ME emulator with libretro, awt and sdl2 frontends.
 
 Authors :


### PR DESCRIPTION
Publish pre-built artifacts so that some people have `Java` but don't have `ant` can just download the `JAR` artifact and try it out.