### PR TITLE
Fix SDL2 frontend build failure for linux relating to linker option order in Makefile 

### DIFF
--- a/src/sdl2/Makefile
+++ b/src/sdl2/Makefile
@@ -3,7 +3,7 @@
 # Make file for Anbu and SDL_interface
 all: anbu.cpp
 	@echo "Building Anbu, sdl_interface for FreeJ2ME ..."
-	@g++ -std=c++11 -lSDL2 -lpthread -lfreeimage -o sdl_interface anbu.cpp
+	@g++ -std=c++11 -o sdl_interface anbu.cpp -lSDL2 -lpthread -lfreeimage 
 
 install:
 	@echo "Installing interface to /usr/local/bin/"


### PR DESCRIPTION
The order in which the link options are placed in relation to the input files matter for certain linkers (gnu ld, for example)

GCC docs: https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
Relevant excerpt:

> -llibrary
-l library
>[...]
>It makes a difference where in the command you write this option; the linker searches and processes libraries and object files in the order they are specified. Thus, ‘foo.o -lz bar.o’ searches library ‘z’ after file foo.o but before bar.o. If bar.o refers to functions in ‘z’, those functions may not be loaded. 

Interesting stack overflow question on the subject: https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc