### PR TITLE
fix #52 - Override parent version of `fillTriangle`

### DIFF
--- a/src/org/recompile/mobile/PlatformGraphics.java
+++ b/src/org/recompile/mobile/PlatformGraphics.java
@@ -523,6 +523,12 @@ public class PlatformGraphics extends javax.microedition.lcdui.Graphics implemen
 		setColor(temp);
 	}
 
+	public void fillTriangle(int x1, int y1, int x2, int y2, int x3, int y3)
+	{
+		//System.out.println("fillTriangle"); // Found In Use
+		gc.fillPolygon(new int[]{x1,x2,x3}, new int[]{y1,y2,y3}, 3);
+	}
+
 	public void fillTriangle(int x1, int y1, int x2, int y2, int x3, int y3, int argbColor)
 	{
 		//System.out.println("fillTriangle"); // Found In Use


### PR DESCRIPTION
Give your love to @vadosnaprimer please, who if nothing else took considerable verbal abuse while helping me work this out and did just as much if not more of the brain work part of this fix.