### PR TITLE
Motorola keypad suport and small fixes for Siemens devices

### DIFF
--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -69,7 +69,7 @@ public class Config
 		menu.add(new String[]{"96x65","96x96","104x80","128x128","132x176","128x160","176x208","176x220", "208x208", "240x320", "320x240", "240x400", "360x640", "480x800"}); // 1 - Size
 		menu.add(new String[]{"Quit", "Main Menu"}); // 2 - Restart Notice
 		menu.add(new String[]{"On", "Off"}); // 3 - sound
-		menu.add(new String[]{"Standard", "Nokia", "Siemens"}); // 4 - Phone 
+		menu.add(new String[]{"Standard", "Nokia", "Siemens","Motorola"}); // 4 - Phone 
 		menu.add(new String[]{"On", "Off"}); // 5 - rotate 
 		menu.add(new String[]{"Auto", "60 - Fast", "30 - Slow", "15 - Turtle"}); // 6 - FPS
 
@@ -134,6 +134,7 @@ public class Config
 					parts[1] = parts[1].trim();
 					if(parts[0]!="" && parts[1]!="")
 					{
+						//Compatibility with the deprecated "nokia" boolean setting
 						if(parts[0].equals("nokia"))
 						{
 							parts[0] = "phone";
@@ -227,6 +228,16 @@ public class Config
 						case Mobile.SIEMENS_UP: itemid--; break;
 						case Mobile.SIEMENS_DOWN: itemid++; break;
 						case Mobile.SIEMENS_SOFT1: menuid=0; break;
+					}
+				}
+				if(settings.get("phone").equals("Motorola"))
+				{
+					switch(key)
+					{
+						case Mobile.MOTOROLA_UP: itemid--; break;
+						case Mobile.MOTOROLA_DOWN: itemid++; break;
+						case Mobile.MOTOROLA_SOFT1: menuid=0; break;
+						case Mobile.MOTOROLA_FIRE: doMenuAction(); break;
 					}
 				}
 		}
@@ -368,6 +379,7 @@ public class Config
 				if(itemid==0) { updatePhone("Standard"); }
 				if(itemid==1) { updatePhone("Nokia"); }
 				if(itemid==2) { updatePhone("Siemens"); }
+				if(itemid==3) { updatePhone("Motorola"); }
 				menuid=0; itemid=0;
 			break;
 

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -66,7 +66,7 @@ public class Config
 
 		menu = new ArrayList<String[]>();
 		menu.add(new String[]{"Resume Game", "Display Size", "Sound", "Limit FPS", "Phone", "Rotate", "Exit"}); // 0 - Main Menu
-		menu.add(new String[]{"96x65","96x96","104x80","128x128","128x160","176x208","176x220", "208x208", "240x320", "320x240", "240x400", "360x640", "480x800"}); // 1 - Size
+		menu.add(new String[]{"96x65","96x96","104x80","128x128","132x176","128x160","176x208","176x220", "208x208", "240x320", "320x240", "240x400", "360x640", "480x800"}); // 1 - Size
 		menu.add(new String[]{"Quit", "Main Menu"}); // 2 - Restart Notice
 		menu.add(new String[]{"On", "Off"}); // 3 - sound
 		menu.add(new String[]{"Standard", "Nokia", "Siemens"}); // 4 - Phone 

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -284,6 +284,7 @@ public class FreeJ2ME
 				case KeyEvent.VK_RIGHT: return Mobile.SIEMENS_RIGHT;
 				case KeyEvent.VK_Q: return Mobile.SIEMENS_SOFT1;
 				case KeyEvent.VK_W: return Mobile.SIEMENS_SOFT2;
+				case KeyEvent.VK_ENTER: return Mobile.SIEMENS_FIRE;
 			}
 		}
 

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -51,6 +51,7 @@ public class FreeJ2ME
 	private Config config;
 	private boolean useNokiaControls = false;
 	private boolean useSiemensControls = false;
+	private boolean useMotorolaControls = false;
 	private boolean rotateDisplay = false;
 	private int limitFPS = 0;
 
@@ -239,10 +240,13 @@ public class FreeJ2ME
 		String phone = config.settings.get("phone");
 		useNokiaControls = false;
 		useSiemensControls = false;
+		useMotorolaControls = false;
 		Mobile.nokia = false;
 		Mobile.siemens = false;
+		Mobile.motorola = false;
 		if(phone.equals("Nokia")) { Mobile.nokia = true; useNokiaControls = true; }
 		if(phone.equals("Siemens")) { Mobile.siemens = true; useSiemensControls = true; }
+		if(phone.equals("Motorola")) { Mobile.motorola = true; useMotorolaControls = true; }
 
 		if(lcdWidth != w || lcdHeight != h)
 		{
@@ -280,6 +284,20 @@ public class FreeJ2ME
 				case KeyEvent.VK_RIGHT: return Mobile.SIEMENS_RIGHT;
 				case KeyEvent.VK_Q: return Mobile.SIEMENS_SOFT1;
 				case KeyEvent.VK_W: return Mobile.SIEMENS_SOFT2;
+			}
+		}
+
+		if(useMotorolaControls)
+		{
+			switch(keycode)
+			{
+				case KeyEvent.VK_UP: return Mobile.MOTOROLA_UP;
+				case KeyEvent.VK_DOWN: return Mobile.MOTOROLA_DOWN;
+				case KeyEvent.VK_LEFT: return Mobile.MOTOROLA_LEFT;
+				case KeyEvent.VK_RIGHT: return Mobile.MOTOROLA_RIGHT;
+				case KeyEvent.VK_Q: return Mobile.MOTOROLA_SOFT1;
+				case KeyEvent.VK_W: return Mobile.MOTOROLA_SOFT2;
+				case KeyEvent.VK_ENTER: return Mobile.MOTOROLA_FIRE;
 			}
 		}
 

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -46,6 +46,7 @@ public class Libretro
 	private Config config;
 	private boolean useNokiaControls = false;
 	private boolean useSiemensControls = false;
+	private boolean useMotorolaControls = false;
 	private boolean rotateDisplay = false;
 	private int limitFPS = 0;
 
@@ -290,10 +291,13 @@ public class Libretro
 		String phone = config.settings.get("phone");
 		useNokiaControls = false;
 		useSiemensControls = false;
+		useMotorolaControls = false;
 		Mobile.nokia = false;
 		Mobile.siemens = false;
+		Mobile.motorola = false;
 		if(phone.equals("Nokia")) { Mobile.nokia = true; useNokiaControls = true; }
 		if(phone.equals("Siemens")) { Mobile.siemens = true; useSiemensControls = true; }
+		if(phone.equals("Motorola")) { Mobile.motorola = true; useMotorolaControls = true; }
 
 		String rotate = config.settings.get("rotate");
 		if(rotate.equals("on")) { rotateDisplay = true; frameHeader[5] = (byte)1; }
@@ -355,6 +359,20 @@ public class Libretro
 				case 119: return Mobile.SIEMENS_SOFT2;
 				case 91: return Mobile.SIEMENS_SOFT1;
 				case 93: return Mobile.SIEMENS_SOFT2;
+			}
+		}
+		if(useMotorolaControls)
+		{
+			switch(keycode)
+			{
+				case 273: return Mobile.MOTOROLA_UP;
+				case 274: return Mobile.MOTOROLA_DOWN;
+				case 276: return Mobile.MOTOROLA_LEFT;
+				case 275: return Mobile.MOTOROLA_RIGHT;
+				case 113: return Mobile.MOTOROLA_SOFT1;
+				case 119: return Mobile.MOTOROLA_SOFT2;
+				case 91: return Mobile.MOTOROLA_SOFT1;
+				case 93: return Mobile.MOTOROLA_SOFT2;
 			}
 		}
 

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -359,6 +359,7 @@ public class Libretro
 				case 119: return Mobile.SIEMENS_SOFT2;
 				case 91: return Mobile.SIEMENS_SOFT1;
 				case 93: return Mobile.SIEMENS_SOFT2;
+				case 13: return Mobile.SIEMENS_FIRE;
 			}
 		}
 		if(useMotorolaControls)
@@ -373,6 +374,7 @@ public class Libretro
 				case 119: return Mobile.MOTOROLA_SOFT2;
 				case 91: return Mobile.MOTOROLA_SOFT1;
 				case 93: return Mobile.MOTOROLA_SOFT2;
+				case 13: return Mobile.MOTOROLA_FIRE;
 			}
 		}
 

--- a/src/org/recompile/mobile/Mobile.java
+++ b/src/org/recompile/mobile/Mobile.java
@@ -44,8 +44,11 @@ public class Mobile
 
 	public static boolean siemens = false;
 
+	public static boolean motorola = false;
+
 	public static boolean sound = true;
 
+	//Standard keycodes
 	public static final int KEY_NUM0  = Canvas.KEY_NUM0;  // 48
 	public static final int KEY_NUM1  = Canvas.KEY_NUM1;  // 49
 	public static final int KEY_NUM2  = Canvas.KEY_NUM2;  // 50
@@ -68,6 +71,7 @@ public class Mobile
 	public static final int GAME_C    = Canvas.GAME_C; // 11
 	public static final int GAME_D    = Canvas.GAME_D; // 12
 
+	//Nokia-specific keycodes
 	public static final int NOKIA_UP    = -1; // KEY_UP_ARROW = -1;
 	public static final int NOKIA_DOWN  = -2; // KEY_DOWN_ARROW = -2;
 	public static final int NOKIA_LEFT  = -3; // KEY_LEFT_ARROW = -3;
@@ -78,6 +82,7 @@ public class Mobile
 	public static final int NOKIA_END   = -11; // KEY_END = -11;
 	public static final int NOKIA_SEND  = -10; // KEY_SEND = -10;
 
+	//Siemens-specific keycodes
 	public static final int SIEMENS_UP    = -59;
 	public static final int SIEMENS_DOWN  = -60;
 	public static final int SIEMENS_LEFT  = -61;
@@ -85,6 +90,15 @@ public class Mobile
 	public static final int SIEMENS_SOFT1 = -1; 
 	public static final int SIEMENS_SOFT2 = -4; 
 	public static final int SIEMENS_FIRE = -26; 
+
+	//Motorola-specific keycodes
+	public static final int MOTOROLA_UP    = -1;
+	public static final int MOTOROLA_DOWN  = -6;
+	public static final int MOTOROLA_LEFT  = -2;
+	public static final int MOTOROLA_RIGHT = -5;
+	public static final int MOTOROLA_SOFT1 = -21; 
+	public static final int MOTOROLA_SOFT2 = -22; 
+	public static final int MOTOROLA_FIRE = -20; 
 
 	public static MobilePlatform getPlatform()
 	{


### PR DESCRIPTION
6fa59b4 adds a Motorola keypad mode to the standard and libretro frontends (The most popular RAZR V3 keycode variant. If you're curious, I try to keep some of the other obscure variants Motorola used documented here https://github.com/Nokia64/J2ME-phone-quirks/blob/master/J2ME-phone-quirks.csv , using emulators and official docs as a reference. Any help is appreciated 😄)
4da1286 adds handling of the Siemens fire key. The constants were already defined at `org.recompile.mobile.Mobile` but it was left unused
a787565 adds the 132x176 resolution to the settings menu. Most games requiring the "Siemens" keypad mode usually work at this one. Decided to sneak it in here instead of opening another pull request for it, hope that's okay