### PR TITLE
Fix PlatformImage.transformImage() transformations 4,6 and 7 (for #98 )

### DIFF
--- a/src/org/recompile/mobile/PlatformGraphics.java
+++ b/src/org/recompile/mobile/PlatformGraphics.java
@@ -640,11 +640,11 @@ public class PlatformGraphics extends javax.microedition.lcdui.Graphics implemen
 			case DirectGraphics.FLIP_VERTICAL: 
 				return PlatformImage.transformImage(image, Sprite.TRANS_MIRROR_ROT180);
 			case DirectGraphics.ROTATE_90: 
-				return PlatformImage.transformImage(image, Sprite.TRANS_ROT90);
+				return PlatformImage.transformImage(image, Sprite.TRANS_ROT270);
 			case DirectGraphics.ROTATE_180:
 				return PlatformImage.transformImage(image, Sprite.TRANS_ROT180);
 			case DirectGraphics.ROTATE_270:
-				return PlatformImage.transformImage(image, Sprite.TRANS_ROT270);
+				return PlatformImage.transformImage(image, Sprite.TRANS_ROT90);
 			case HV:
 				return PlatformImage.transformImage(image, Sprite.TRANS_ROT180);
 			case H90: 

--- a/src/org/recompile/mobile/PlatformImage.java
+++ b/src/org/recompile/mobile/PlatformImage.java
@@ -264,8 +264,8 @@ public class PlatformImage extends javax.microedition.lcdui.Image
 				break;
 			
 			case Sprite.TRANS_ROT270:
-				af.translate(height, 0);
-				af.rotate(Math.PI / 2);
+				af.translate(0, width);
+				af.rotate(Math.PI * 3 / 2);
 				out_width = height;
 				out_height = width;
 				break;
@@ -276,10 +276,10 @@ public class PlatformImage extends javax.microedition.lcdui.Image
 				break;
 
 			case Sprite.TRANS_MIRROR_ROT90: 
-				af.translate(width, 0);
-				af.scale(-1, 1);
 				af.translate(height, 0);
 				af.rotate(Math.PI / 2);
+				af.translate(width, 0);
+				af.scale(-1, 1);
 				out_width = height;
 				out_height = width;
 				break;
@@ -292,7 +292,7 @@ public class PlatformImage extends javax.microedition.lcdui.Image
 				break;
 
 			case Sprite.TRANS_MIRROR_ROT270: 
-				af.translate(height, 0);
+				af.translate(0, width);
 				af.rotate(Math.PI * 3 / 2);
 				af.translate(width, 0);
 				af.scale(-1, 1);


### PR DESCRIPTION
This fixes transformations 4 (`TRANS_MIRROR_ROT270`), 6 (`TRANS_ROT270`) and 7 (`TRANS_MIRROR_ROT90`) at `org.recompile.mobile.PlatformImage`, making the results match real devices.
![freej2me-fix](https://user-images.githubusercontent.com/57576450/123552742-05922800-d767-11eb-994a-4356d9d28b46.png)
