### PR TITLE
Image.createImage() exception throwing improvements and a tiny fix

### DIFF
--- a/src/javax/microedition/lcdui/Image.java
+++ b/src/javax/microedition/lcdui/Image.java
@@ -50,7 +50,7 @@ public class Image
 	public static Image createImage(Image img, int x, int y, int width, int height, int transform)
 	{
 		//System.out.println("Create Image from sub-image ");
-		PlatformImage t = new PlatformImage(width-x, height-y);
+		PlatformImage t = new PlatformImage(img, x, y, width, height, transform);
 		if(t.isNull) { return (Image)null; }
 		return t;
 	}

--- a/src/javax/microedition/lcdui/Image.java
+++ b/src/javax/microedition/lcdui/Image.java
@@ -16,6 +16,7 @@
 */
 package javax.microedition.lcdui;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 
@@ -34,52 +35,60 @@ public class Image
 	public static Image createImage(byte[] imageData, int imageOffset, int imageLength)
 	{
 		//System.out.println("Create Image from image data ");
+		if (imageData == null) {throw new NullPointerException();}
+		if (imageOffset + imageLength > imageData.length) {throw new ArrayIndexOutOfBoundsException();}
 		PlatformImage t = new PlatformImage(imageData, imageOffset, imageLength);
-		if(t.isNull) { return (Image)null; }
+		if(t.isNull) { throw new IllegalArgumentException(); }
 		return t;
 	}
 
 	public static Image createImage(Image source)
 	{
 		//System.out.println("Create Image from Image ");
-		PlatformImage t = new PlatformImage(source);
-		if(t.isNull) { return (Image)null; }
-		return t;
+		if (source == null) {throw new NullPointerException();}
+		return new PlatformImage(source);
 	}
 
 	public static Image createImage(Image img, int x, int y, int width, int height, int transform)
 	{
-		//System.out.println("Create Image from sub-image ");
-		PlatformImage t = new PlatformImage(img, x, y, width, height, transform);
-		if(t.isNull) { return (Image)null; }
-		return t;
+		//System.out.println("Create Image from sub-image " + " img_w:" + Integer.toString(img.getWidth()) + " img_h:" + Integer.toString(img.getHeight()) + " x:" + Integer.toString(x) + " y:" + Integer.toString(y) + " width:" + Integer.toString(width) + " height:" + Integer.toString(height));
+		if (img == null) {throw new NullPointerException();}
+		if (x+width > img.getWidth() || y+height > img.getHeight()) {throw new IllegalArgumentException();}
+		if (width <= 0 || height <= 0) {throw new IllegalArgumentException();}
+		return new PlatformImage(img, x, y, width, height, transform);
 	}
 
-	public static Image createImage(InputStream stream)
+	public static Image createImage(InputStream stream) throws IOException
 	{
 		//System.out.println("Create Image stream");
+		if (stream == null) {throw new NullPointerException();}
 		PlatformImage t = new PlatformImage(stream);
-		if(t.isNull) { return (Image)null; }
+		if(t.isNull) { throw new IOException(); }
 		return t;
 	}
 
 	public static Image createImage(int width, int height)
 	{
 		//System.out.println("Create Image w,h " + width + ", " + height);
+		if (width <= 0 || height <= 0) {throw new IllegalArgumentException();}
 		return new PlatformImage(width, height);
 	}
 
-	public static Image createImage(String name)
+	public static Image createImage(String name) throws IOException
 	{
 		//System.out.println("Create Image " + name);
+		if (name == null) {throw new NullPointerException();}
 		PlatformImage t = new PlatformImage(name);
-		if(t.isNull) { return (Image)null; }
+		if(t.isNull) { throw new IOException(); }
 		return t;
 	}
 
 	public static Image createRGBImage(int[] rgb, int width, int height, boolean processAlpha)
 	{
 		//System.out.println("Create Image RGB " + width + ", " + height);
+		if (rgb == null) {throw new NullPointerException();}
+		if (width <= 0 || height <= 0) {throw new IllegalArgumentException();}
+		if (rgb.length < width * height) {throw new ArrayIndexOutOfBoundsException();}
 		return new PlatformImage(rgb, width, height, processAlpha);
 	}
 


### PR DESCRIPTION
Improved the exception throwing done by the `javax.microedition.lcdui.Image.createImage()` methods for better compilance with the MIDP standard, fixes #89

Also, the "image from sub-image" createImage() method wasn't using the proper PlatformImage constructor leading to blank images or crashes instead
Before/after 9fa8df2 (_Cannonball_ by Bluette/wait4u)
![Cannonball-pre](https://user-images.githubusercontent.com/57576450/145305981-d6428919-2fdc-46aa-bdd3-2759374b6bb9.png) ![Cannonball-post](https://user-images.githubusercontent.com/57576450/145305986-3c78e70a-0a28-4dd4-8309-a7360b5a1181.png)
