### PR TITLE
Fix for #122

### DIFF
--- a/src/org/recompile/mobile/PlatformGraphics.java
+++ b/src/org/recompile/mobile/PlatformGraphics.java
@@ -347,10 +347,8 @@ public class PlatformGraphics extends javax.microedition.lcdui.Graphics implemen
 		translateX += x;
 		translateY += y;
 		gc.translate(x, y);
-		clipX = (int)gc.getClipBounds().getX();
-		clipY = (int)gc.getClipBounds().getY();
-		clipWidth = (int)gc.getClipBounds().getWidth();
-		clipHeight = (int)gc.getClipBounds().getHeight();
+		clipX -= x;
+		clipY -= y;
 	}
 
 	private int AnchorX(int x, int width, int anchor)

--- a/src/org/recompile/mobile/PlatformGraphics.java
+++ b/src/org/recompile/mobile/PlatformGraphics.java
@@ -347,6 +347,10 @@ public class PlatformGraphics extends javax.microedition.lcdui.Graphics implemen
 		translateX += x;
 		translateY += y;
 		gc.translate(x, y);
+		clipX = (int)gc.getClipBounds().getX();
+		clipY = (int)gc.getClipBounds().getY();
+		clipWidth = (int)gc.getClipBounds().getWidth();
+		clipHeight = (int)gc.getClipBounds().getHeight();
 	}
 
 	private int AnchorX(int x, int width, int anchor)


### PR DESCRIPTION
Tiny fix for issue #122, calls to Graphics.translate(int x, int y) may have effects over the clip area values but they weren't being updated on FreeJ2ME's side causing issues on some games relying on reading back these values

EDIT: After testing some more games, I've noticed the first fix could cause a NullPointerException since Graphics2D.getClipBounds() may return null if the clip area had never been set. Added another commit on top, which instead updates the variables manually. Also the width and height never change so there's no need to update them