### PR TITLE
Keep a same Graphics object for all paint() calls

### DIFF
--- a/src/javax/microedition/lcdui/Canvas.java
+++ b/src/javax/microedition/lcdui/Canvas.java
@@ -18,6 +18,7 @@ package javax.microedition.lcdui;
 
 import org.recompile.mobile.Mobile;
 import org.recompile.mobile.PlatformImage;
+import org.recompile.mobile.PlatformGraphics;
 
 public abstract class Canvas extends Displayable
 {
@@ -156,9 +157,12 @@ public abstract class Canvas extends Displayable
 
 	public void repaint()
 	{
+		PlatformGraphics graphics;
 		try
 		{
-			paint(platformImage.getNewGraphics());
+			graphics = platformImage.getGraphics();
+			graphics.reset();
+			paint(graphics);
 			if(Mobile.getDisplay().getCurrent() == this)
 			{
 				Mobile.getPlatform().repaint(platformImage, 0, 0, width, height);
@@ -173,7 +177,9 @@ public abstract class Canvas extends Displayable
 
 	public void repaint(int x, int y, int width, int height)
 	{
-		paint(platformImage.getNewGraphics());
+		PlatformGraphics graphics = platformImage.getGraphics();
+		graphics.reset();
+		paint(graphics);
 		if(Mobile.getDisplay().getCurrent() == this)
 		{
 			Mobile.getPlatform().repaint(platformImage, x, y, width, height);

--- a/src/org/recompile/mobile/PlatformGraphics.java
+++ b/src/org/recompile/mobile/PlatformGraphics.java
@@ -61,6 +61,15 @@ public class PlatformGraphics extends javax.microedition.lcdui.Graphics implemen
 		gc.setFont(font.platformFont.awtFont);
 	}
 
+	public void reset() //Internal use method, resets the Graphics object to its inital values
+	{
+		translate(-1 * translateX, -1 * translateY);
+		setClip(0, 0, canvas.getWidth(), canvas.getHeight());
+		setColor(0,0,0);
+		setFont(Font.getDefaultFont());
+		setStrokeStyle(SOLID);
+	}
+
 	public Graphics2D getGraphics2D()
 	{
 		return gc;

--- a/src/org/recompile/mobile/PlatformImage.java
+++ b/src/org/recompile/mobile/PlatformImage.java
@@ -49,12 +49,6 @@ public class PlatformImage extends javax.microedition.lcdui.Image
 		return gc;
 	}
 
-	public PlatformGraphics getNewGraphics()
-	{
-		createGraphics();
-		return gc;
-	}
-
 	protected void createGraphics()
 	{
 		gc = new PlatformGraphics(this);


### PR DESCRIPTION
Fix for #124 (while keeping #61 happy)
Some games using DirectUtils.getDirectGraphics(Graphics g) rely on the underlying Graphics object of the returned DirectGraphics being the same across all calls to paint(), while FreeJ2ME was creating a new object per call