### PR TITLE
Fix WAV sound (re)playback

### DIFF
--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -286,7 +286,12 @@ public class PlatformPlayer implements Player
 
 		public void start()
 		{
-			if(isRunning()) { wavClip.setFramePosition(0); }
+			if(isRunning()) {
+				return;
+			}
+			if(wavClip.getFramePosition() >= wavClip.getFrameLength()) {
+				wavClip.setFramePosition(0);
+			}
 			time = wavClip.getMicrosecondPosition();
 			wavClip.start();
 			state = Player.STARTED;


### PR DESCRIPTION
Fix for issue #127, preventing playback of WAV sounds more than once. Also makes stopped sounds continue from where paused instead of restarting from the beginning, in accordance with the MIDP specification