### PR TITLE
Add handling of Siemens and Motorola keycodes to Libretro getMobileKeyJoy()

### DIFF
--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -441,6 +441,31 @@ public class Libretro
 				case 3: return Mobile.NOKIA_RIGHT; // Right
 			}
 		}
+		if(useSiemensControls)
+		{
+			switch(keycode)
+			{
+				case 0: return Mobile.SIEMENS_UP; // Up
+				case 1: return Mobile.SIEMENS_DOWN; // Down
+				case 2: return Mobile.SIEMENS_LEFT; // Left
+				case 3: return Mobile.SIEMENS_RIGHT; // Right
+				case 8: return Mobile.SIEMENS_SOFT2; // Start
+				case 9: return Mobile.SIEMENS_SOFT1; // Select
+			}
+		}
+		if(useMotorolaControls)
+		{
+			switch(keycode)
+			{
+				case 0: return Mobile.MOTOROLA_UP; // Up
+				case 1: return Mobile.MOTOROLA_DOWN; // Down
+				case 2: return Mobile.MOTOROLA_LEFT; // Left
+				case 3: return Mobile.MOTOROLA_RIGHT; // Right
+				case 8: return Mobile.MOTOROLA_SOFT2; // Start
+				case 9: return Mobile.MOTOROLA_SOFT1; // Select
+			}
+		}
+
 		switch(keycode)
 		{
 			case 0: return Mobile.KEY_NUM2; // Up


### PR DESCRIPTION
 Commits 463b516 and 6fa59b4 added support for Siemens and Motorola keycodes in the `getMobileKey` function of Libretro frontend (used for handling keyboard input), but the `getMobileKeyJoy` function which is used instead for handling the input from joypad devices was left unmodified leaving these unable to produce the newly introduced device-specific keycodes.

This small patch adds such support to the `getMobileKeyJoy` function.