### PR TITLE
KeyRepeated event support

### DIFF
--- a/src/javax/microedition/lcdui/Canvas.java
+++ b/src/javax/microedition/lcdui/Canvas.java
@@ -135,7 +135,7 @@ public abstract class Canvas extends Displayable
 
 	public boolean hasPointerMotionEvents() { return false; }
 
-	public boolean hasRepeatEvents() { return false; }
+	public boolean hasRepeatEvents() { return true; }
 
 	public void hideNotify() { }
 

--- a/src/javax/microedition/lcdui/Displayable.java
+++ b/src/javax/microedition/lcdui/Displayable.java
@@ -94,6 +94,7 @@ public abstract class Displayable
 
 	public void keyPressed(int key) { }
 	public void keyReleased(int key) { }
+	public void keyRepeated(int key) { }
 	public void pointerDragged(int x, int y) { }
 	public void pointerPressed(int x, int y) { }
 	public void pointerReleased(int x, int y) { }

--- a/src/org/recompile/mobile/MobilePlatform.java
+++ b/src/org/recompile/mobile/MobilePlatform.java
@@ -102,6 +102,11 @@ public class MobilePlatform
 		Mobile.getDisplay().getCurrent().keyReleased(keycode);
 	}
 
+	public void keyRepeated(int keycode)
+	{
+		Mobile.getDisplay().getCurrent().keyRepeated(keycode);
+	}
+
 	public void pointerDragged(int x, int y)
 	{
 		Mobile.getDisplay().getCurrent().pointerDragged(x, y);


### PR DESCRIPTION
This brings in the changes discussed at issue #130 plus the patch for the Libretro frontend, implemented in a similar fashion to the AWT one (I have _squashed_ the various intermediate work state commits from my repeat-events-support branch into three final per-frontend ones, for the sake of cleanness)

For now `hasRepeatEvents()` is harcoded to always return `true` as the three frontends do currently support them. May take a look later into making that per-frontend as per recompileorg's suggestions.

Hopefully this should solve quirks across many games... not introducing new ones 😅
Thank you!