### PR TITLE
 Improvements to the libretro core's shutdown and restart procedures. (renamed branch)

### DIFF
--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -112,7 +112,7 @@ void quit(int state)
 	{
 		kill(javaProcess, SIGKILL);
 	}
-	exit(state);
+	//exit(state);
 }
 
 static void Keyboard(bool down, unsigned keycode, uint32_t character, uint16_t key_modifiers)

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -74,6 +74,7 @@ unsigned int frameBufferSize = 1920000;
 unsigned int frame[640000];
 unsigned char frameBuffer[1920000];
 unsigned char frameHeader[5];
+struct retro_game_info gameinfo;
 
 bool frameRequested = false;
 int framesDropped = 0;
@@ -162,6 +163,8 @@ bool retro_load_game(const struct retro_game_info *info)
 {
 	int len = 0;
 
+	//Game info is passed to a global variable to enable restarts
+	gameinfo = *info;
 	// Send savepath to java
 	char *savepath;
 	Environ(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &savepath);
@@ -535,7 +538,9 @@ void retro_deinit(void)
 
 void retro_reset(void)
 {
-	quit(0);
+	retro_deinit();
+	retro_init();
+	retro_load_game(&gameinfo);
 }
 
 /* Stubs */


### PR DESCRIPTION
Previously, it had a tendency to close the entire frontend whenever a "Close Content" or "Restart" callback was issued, now only the core is closed, and a restart triggers a full core reload to allow the incoming core config options to be applied.

Decided to rename the branch since i'm thinking of pushing multiple PR's related to different parts of FreeJ2ME.