### PR TITLE
Improve FreeJ2ME's standalone and libretro core save paths.

### DIFF
--- a/src/javax/microedition/rms/RecordStore.java
+++ b/src/javax/microedition/rms/RecordStore.java
@@ -244,7 +244,7 @@ public class RecordStore
 	{
 		try
 		{
-			File fstore = new File("rms/"+Mobile.getPlatform().loader.suitename+"/"+recordStoreName);
+			File fstore = new File(Mobile.getPlatform().dataPath + "./rms/"+Mobile.getPlatform().loader.suitename+"/"+recordStoreName);
 			fstore.delete();
 		}
 		catch (Exception e)
@@ -347,7 +347,7 @@ public class RecordStore
 		//System.out.println("List Record Stores");
 		if(rmsPath==null)
 		{
-			rmsPath = "rms/"+Mobile.getPlatform().loader.name;
+			rmsPath = Mobile.getPlatform().dataPath + "./rms/"+Mobile.getPlatform().loader.name;
 			try
 			{
 				Files.createDirectories(Paths.get(rmsPath));

--- a/src/javax/microedition/rms/RecordStore.java
+++ b/src/javax/microedition/rms/RecordStore.java
@@ -70,8 +70,8 @@ public class RecordStore
 
 		appname = Mobile.getPlatform().loader.suitename;
 
-		rmsPath = Mobile.getPlatform().dataPath + "/rms/"+appname;
-		rmsFile = Mobile.getPlatform().dataPath + "/rms/"+appname+"/"+recordStoreName;
+		rmsPath = Mobile.getPlatform().dataPath + "./rms/"+appname;
+		rmsFile = Mobile.getPlatform().dataPath + "./rms/"+appname+"/"+recordStoreName;
 
 		try
 		{

--- a/src/javax/microedition/rms/RecordStore.java
+++ b/src/javax/microedition/rms/RecordStore.java
@@ -70,8 +70,8 @@ public class RecordStore
 
 		appname = Mobile.getPlatform().loader.suitename;
 
-		rmsPath = "rms/"+appname;
-		rmsFile = "rms/"+appname+"/"+recordStoreName;
+		rmsPath = Mobile.getPlatform().dataPath + "/rms/"+appname;
+		rmsFile = Mobile.getPlatform().dataPath + "/rms/"+appname+"/"+recordStoreName;
 
 		try
 		{

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -181,7 +181,7 @@ bool retro_load_game(const struct retro_game_info *info)
 	unsigned char saveevent[5] = { 0xB, (len>>24)&0xFF, (len>>16)&0xFF, (len>>8)&0xFF, len&0xFF };
 	write(pWrite[1], saveevent, 5);
 	write(pWrite[1], savepath, len-9);
-	write(pWrite[1], "freej2me/", 9);
+	write(pWrite[1], "/freej2me/", 9);
 
 	// Tell java app to load and run game //
 	len = strlen(info->path);

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -176,12 +176,12 @@ bool retro_load_game(const struct retro_game_info *info)
 		len = strlen(savepath);
 	}
 
-	len += 9;
+	len += 10;
 
 	unsigned char saveevent[5] = { 0xB, (len>>24)&0xFF, (len>>16)&0xFF, (len>>8)&0xFF, len&0xFF };
 	write(pWrite[1], saveevent, 5);
-	write(pWrite[1], savepath, len-9);
-	write(pWrite[1], "/freej2me/", 9);
+	write(pWrite[1], savepath, len-10);
+	write(pWrite[1], "/freej2me/", 10);
 
 	// Tell java app to load and run game //
 	len = strlen(info->path);

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -86,7 +86,7 @@ public class Config
 	public void init()
 	{
 		String appname = Mobile.getPlatform().loader.suitename;
-		configPath = Mobile.getPlatform().dataPath + "config/"+appname;
+		configPath = Mobile.getPlatform().dataPath + "/config/"+appname;
 		configFile = configPath + "/game.conf";
 		// Load Config //
 		try

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -86,7 +86,7 @@ public class Config
 	public void init()
 	{
 		String appname = Mobile.getPlatform().loader.suitename;
-		configPath = Mobile.getPlatform().dataPath + "/config/"+appname;
+		configPath = Mobile.getPlatform().dataPath + "./config/"+appname;
 		configFile = configPath + "/game.conf";
 		// Load Config //
 		try


### PR DESCRIPTION
Previously the RA core would save configs incorrectly, now the folders are better organized, and the code was altered in a way that doesn't cause problems for the standalone versions of FreeJ2ME. Refer to #138 for more info about this.

~~Edit: Don't merge yet, just found a bug on DOOM II RPG through the libretro frontend.~~

Edit 2: Alright, now it should be fine.