### PR TITLE
Improving the audio subsystem.

### DIFF
--- a/src/javax/microedition/media/Manager.java
+++ b/src/javax/microedition/media/Manager.java
@@ -41,7 +41,8 @@ public final class Manager
 	public static String[] getSupportedContentTypes(String protocol)
 	{
 		//System.out.println("Get Supported Media Content Types");
-		return new String[]{"audio/midi", "audio/x-wav"};
+		return new String[]{"audio/midi", "audio/x-wav", 
+		"audio/amr", "audio/mpeg"};
 	}
 	
 	public static String[] getSupportedProtocols(String content_type)

--- a/src/javax/microedition/media/Manager.java
+++ b/src/javax/microedition/media/Manager.java
@@ -29,7 +29,6 @@ public final class Manager
 
 	public static Player createPlayer(InputStream stream, String type) throws IOException, MediaException
 	{
-		if(stream == null) { throw new IllegalArgumentException(); } 
 		//System.out.println("Create Player Stream "+type);
 		return new PlatformPlayer(stream, type);
 	}

--- a/src/javax/microedition/media/Manager.java
+++ b/src/javax/microedition/media/Manager.java
@@ -17,6 +17,7 @@
 package javax.microedition.media;
 
 import java.io.InputStream;
+import java.io.IOException;
 
 import org.recompile.mobile.PlatformPlayer;
 
@@ -26,8 +27,9 @@ public final class Manager
 	public static final String TONE_DEVICE_LOCATOR = "device://tone";
 
 
-	public static Player createPlayer(InputStream stream, String type) throws MediaException
+	public static Player createPlayer(InputStream stream, String type) throws IOException, MediaException
 	{
+		if(stream == null) { throw new IllegalArgumentException(); } 
 		//System.out.println("Create Player Stream "+type);
 		return new PlatformPlayer(stream, type);
 	}

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -56,13 +56,13 @@ public class PlatformPlayer implements Player
 		}
 		else
 		{
-			if(type.equals("audio/mid") || type.equals("Audio/midi") || type.equals("audio/midi") || type.equals("sp-midi") || type.equals("audio/spmidi"))
+			if(type.equalsIgnoreCase("audio/mid") || type.equalsIgnoreCase("audio/midi") || type.equalsIgnoreCase("sp-midi") || type.equalsIgnoreCase("audio/spmidi"))
 			{
 				player = new midiPlayer(stream);
 			}
 			else
 			{
-				if(type.equals("audio/x-wav") || type.equals("audio/X-wav") || type.equals("audio/wav"))
+				if(type.equalsIgnoreCase("audio/x-wav") || type.equalsIgnoreCase("audio/wav"))
 				{
 					player = new wavPlayer(stream);
 				}

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -62,7 +62,7 @@ public class PlatformPlayer implements Player
 			}
 			else
 			{
-				if(type.equals("audio/x-wav"))
+				if(type.equals("audio/x-wav") || type.equals("audio/X-wav"))
 				{
 					player = new wavPlayer(stream);
 				}

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -222,6 +222,8 @@ public class PlatformPlayer implements Player
 
 		public void start()
 		{
+			if(isRunning()) { return; }
+
 			midi.setMicrosecondPosition(0);
 			midi.start();
 			state = Player.STARTED;
@@ -254,7 +256,7 @@ public class PlatformPlayer implements Player
 		}
 		public long getMediaTime()
 		{
-			return 0;
+			return midi.getTickPosition();
 		}
 		public boolean isRunning()
 		{

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -208,7 +208,7 @@ public class PlatformPlayer implements Player
 
 		private int loops = 0;
 
-		private Long tick = new Long(0);
+		private long tick = 0L;
 
 		public midiPlayer(InputStream stream)
 		{
@@ -280,7 +280,7 @@ public class PlatformPlayer implements Player
 
 		private int loops = 0;
 
-		private Long time = new Long(0);
+		private long time = 0L;
 
 		public wavPlayer(InputStream stream)
 		{

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -324,7 +324,12 @@ public class PlatformPlayer implements Player
 
 		public boolean isRunning()
 		{
-			return wavClip.isRunning();
+			if(wavClip == null)
+			{
+				System.out.println("Warning: MIDlet loaded a NULL wavClip, can't use the isRunning() call");
+				return false;
+			}
+			else { return wavClip.isRunning(); }
 		}
 	}
 

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -62,7 +62,7 @@ public class PlatformPlayer implements Player
 			}
 			else
 			{
-				if(type.equalsIgnoreCase("audio/x-wav"))
+				if(type.equalsIgnoreCase("audio/x-wav") || type.equalsIgnoreCase("audio/wav"))
 				{
 					player = new wavPlayer(stream);
 				}
@@ -281,7 +281,11 @@ public class PlatformPlayer implements Player
 				wavClip.open(wavStream);
 				state = Player.PREFETCHED;
 			}
-			catch (Exception e) { }
+			catch (Exception e) 
+			{ 
+				System.out.println("Couldn't load wav file: " + e.getMessage());
+				wavClip.close();
+			}
 		}
 
 		public void start()

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -56,17 +56,17 @@ public class PlatformPlayer implements Player
 		}
 		else
 		{
-			if(type.equals("audio/midi") || type.equals("sp-midi") || type.equals("audio/spmidi"))
+			if(type.equals("audio/mid") || type.equals("Audio/midi") || type.equals("audio/midi") || type.equals("sp-midi") || type.equals("audio/spmidi"))
 			{
 				player = new midiPlayer(stream);
 			}
 			else
 			{
-				if(type.equals("audio/x-wav") || type.equals("audio/X-wav"))
+				if(type.equals("audio/x-wav") || type.equals("audio/X-wav") || type.equals("audio/wav"))
 				{
 					player = new wavPlayer(stream);
 				}
-				else
+				else /* TODO: Implement a player for amr and mpeg audio types */
 				{
 					System.out.println("No Player For: "+contentType);
 					player = new audioplayer();

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -208,6 +208,8 @@ public class PlatformPlayer implements Player
 
 		private int loops = 0;
 
+		private Long tick = new Long(0);
+
 		public midiPlayer(InputStream stream)
 		{
 			try
@@ -224,16 +226,22 @@ public class PlatformPlayer implements Player
 		{
 			if(isRunning()) { return; }
 
-			midi.setMicrosecondPosition(0);
+			if(midi.getTickPosition() >= midi.getTickLength())
+			{
+				midi.setTickPosition(0);
+			}
+			tick = midi.getTickPosition();
 			midi.start();
 			state = Player.STARTED;
-			notifyListeners(PlayerListener.STARTED, new Long(0));
+			notifyListeners(PlayerListener.STARTED, tick);
 		}
 
 		public void stop()
 		{
 			midi.stop();
 			state = Player.PREFETCHED;
+			tick = midi.getTickPosition();
+			notifyListeners(PlayerListener.STOPPED, tick);
 		}
 		public void deallocate()
 		{

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -62,7 +62,7 @@ public class PlatformPlayer implements Player
 			}
 			else
 			{
-				if(type.equalsIgnoreCase("audio/x-wav") || type.equalsIgnoreCase("audio/wav"))
+				if(type.equalsIgnoreCase("audio/x-wav"))
 				{
 					player = new wavPlayer(stream);
 				}
@@ -324,12 +324,7 @@ public class PlatformPlayer implements Player
 
 		public boolean isRunning()
 		{
-			if(wavClip == null)
-			{
-				System.out.println("Warning: MIDlet loaded a NULL wavClip, can't use the isRunning() call");
-				return false;
-			}
-			else { return wavClip.isRunning(); }
+			return wavClip.isRunning();
 		}
 	}
 

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -231,7 +231,7 @@ public class PlatformPlayer implements Player
 		public void stop()
 		{
 			midi.stop();
-			state = Player.REALIZED;
+			state = Player.PREFETCHED;
 		}
 		public void deallocate()
 		{


### PR DESCRIPTION
Taking a break from the libretro core improvements, this one improves the overall compatibility of FreeJ2ME. Many of the games i tested used different media types that actually are the same type as the ones currently implemented, which are "audio/midi" and "audio/x-wav", just worded differently. When situations like those happened, games either ignored the lack of support for the media and didn't play files of that type, or outright crashed. Some even crashed after the extra names were introduced, but i added a try-catch into the PlatformPlayer to deal with those as well.

This Pull Request aims at fixing most of the audio-related crashes that FreeJ2ME currently suffers (didn't face any related to audio anymore, more of a reason not to expose the audio config on the libretro frontend), although it doesn't implement the missing audio types like "audio/amr" and "audio/mpeg" yet. I'm currently building a wiki page with a compatibility list of the games i (and some friends) tested so far, noting games that require those two audio types to some extent, in case anyone wants to take a look at them.

Some of the commits also directly point to the games fixed in each of them.