### PR TITLE
Improvements to FreeJ2ME's game compatibility, and a screen pointer fix when rotated on libretro (redone)

### DIFF
--- a/src/javax/bluetooth/DeviceClass.java
+++ b/src/javax/bluetooth/DeviceClass.java
@@ -1,0 +1,29 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+public abstract class DeviceClass
+{
+
+    public DeviceClass(int record) { System.out.println("DeviceClass record:" + record); }
+
+    public abstract int getMajorDeviceClass();
+
+    public abstract int getMinorDeviceClass();
+
+    public abstract int getServiceClasses();
+} 

--- a/src/javax/bluetooth/DiscoveryAgent.java
+++ b/src/javax/bluetooth/DiscoveryAgent.java
@@ -1,0 +1,43 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+public abstract class DiscoveryAgent
+{
+    
+    public static final int CACHED = 0;
+
+    public static final int GIAC = 10390323;
+
+    public static final int LIAC = 10390272;
+
+    public static final int NOT_DISCOVERABLE = 0;
+    
+    public static final int PREKNOWN = 1;
+
+    public abstract boolean cancelInquiry(DiscoveryListener listener);
+
+    public abstract boolean cancelServiceSearch(int transID);
+
+    public abstract RemoteDevice[] retrieveDevices(int option);
+
+    public abstract int searchServices(int[] attrSet, UUID[] uuidSet, RemoteDevice btDev, DiscoveryListener discListener);
+
+    public abstract String selectService(UUID uuid, int security, boolean master);
+
+    public abstract boolean startInquiry(int accessCode, DiscoveryListener listener);
+}

--- a/src/javax/bluetooth/DiscoveryListener.java
+++ b/src/javax/bluetooth/DiscoveryListener.java
@@ -1,0 +1,45 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+public abstract interface DiscoveryListener
+{
+
+    public static int INQUIRY_COMPLETED = 0;
+
+    public static int INQUIRY_ERROR = 7;
+
+    public static int INQUIRY_TERMINATED = 5;
+
+    public static int SERVICE_SEARCH_COMPLETED = 1;
+
+    public static int SERVICE_SEARCH_DEVICE_NOT_REACHABLE  = 6;
+
+    public static int SERVICE_SEARCH_ERROR = 3;
+
+    public static int SERVICE_SEARCH_NO_RECORDS = 4;
+
+    public static int SERVICE_SEARCH_TERMINATED = 2;
+
+    public abstract void deviceDiscovered(RemoteDevice btDevice, DeviceClass cod);
+
+    public abstract void inquiryCompleted(int discType);
+
+    public abstract void servicesDiscovered(int transID, ServiceRecord[] servRecord);
+
+    public abstract void serviceSearchCompleted(int transID, int respCode);
+}

--- a/src/javax/bluetooth/L2CAPConnection.java
+++ b/src/javax/bluetooth/L2CAPConnection.java
@@ -1,0 +1,39 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+import java.io.IOException;
+
+import javax.microedition.io.Connection;
+
+public interface L2CAPConnection extends Connection 
+{
+
+	public static final int DEFAULT_MTU = 672;
+
+	public static final int MINIMUM_MTU = 48;
+
+	public int getTransmitMTU() throws IOException;
+
+	public int getReceiveMTU() throws IOException;
+
+	public void send(byte[] data) throws IOException;
+
+	public int receive(byte[] inBuf) throws IOException;
+
+	public boolean ready() throws IOException;
+}

--- a/src/javax/bluetooth/L2CAPConnectionNotifier.java
+++ b/src/javax/bluetooth/L2CAPConnectionNotifier.java
@@ -1,0 +1,28 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+import java.io.IOException;
+
+import javax.microedition.io.Connection;
+
+public interface L2CAPConnectionNotifier extends Connection 
+{
+
+	public L2CAPConnection acceptAndOpen() throws IOException;
+
+}

--- a/src/javax/bluetooth/LocalDevice.java
+++ b/src/javax/bluetooth/LocalDevice.java
@@ -1,0 +1,45 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.bluetooth;
+
+import javax.microedition.io.Connection;
+
+
+public abstract class LocalDevice 
+{
+    public abstract String getBluetoothAddress();
+
+    public abstract DeviceClass getDeviceClass();
+
+    public abstract int getDiscoverable();
+
+    public abstract DiscoveryAgent getDiscoveryAgent();
+
+    public abstract String getFriendlyName();
+
+    public abstract LocalDevice getLocalDevice();
+
+    public abstract String getProperty(String property);
+
+    public abstract ServiceRecord getRecord(Connection notifier);
+
+    public static boolean isPowerOn() { return false; /* We won't have functional Bluetooth yet */ }
+
+    public abstract boolean setDiscoverable(int mode);    
+
+    public abstract void updateRecord(ServiceRecord srvRecord);
+}

--- a/src/javax/bluetooth/UUID.java
+++ b/src/javax/bluetooth/UUID.java
@@ -1,0 +1,32 @@
+ 
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.bluetooth;
+
+public abstract class UUID 
+{
+    public UUID(long uuidValue) { System.out.println("UUID Value:" + uuidValue); }
+
+    public UUID(String uuidValue, boolean shortUUID) { System.out.println("UUID Value:" + uuidValue); }
+
+    public abstract boolean equals(Object value);
+
+    public abstract int hashCode();
+
+    public abstract String toString();
+}
+ 

--- a/src/javax/microedition/io/file/ConnectionClosedException.java
+++ b/src/javax/microedition/io/file/ConnectionClosedException.java
@@ -1,0 +1,24 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.microedition.io.file;
+
+public class ConnectionClosedException extends RuntimeException 
+{
+	public ConnectionClosedException() {}
+
+	public ConnectionClosedException(String detailMessage) { System.out.println("ConnectionClosedException: " + detailMessage); }
+}

--- a/src/javax/microedition/io/file/FileConnection.java
+++ b/src/javax/microedition/io/file/FileConnection.java
@@ -1,0 +1,90 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.io.file;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Enumeration;
+
+import javax.microedition.io.StreamConnection;
+
+public interface FileConnection extends StreamConnection 
+{
+    public long availableSize();
+
+    public boolean canRead();
+
+    public boolean canWrite();
+
+    public void create();
+
+    public void delete();
+
+    public long directorySize(boolean includeSubDirs);
+
+    public boolean exists();
+
+    public long fileSize();
+
+    public String getName();
+
+    public String getPath();
+
+    public String getURL();
+
+    public boolean isDirectory();
+
+    public boolean isHidden();
+
+    public boolean isOpen();
+    
+    public long lastModified();
+
+    public Enumeration list();
+
+    public Enumeration list(String filter, boolean includeHidden);
+
+    public void mkdir();
+
+    public DataInputStream openDataInputStream();
+
+    public DataOutputStream openDataOutputStream();
+
+    public InputStream openInputStream();
+
+    public OutputStream openOutputStream();
+
+    public OutputStream openOutputStream(long byteOffset);
+
+    public void rename();
+
+    public void setFileConnection(String fileName);
+
+    public void setHidden(boolean hidden);
+
+    public void setReadable(boolean readable);
+
+    public void setWritable(boolean writable);
+
+    public long totalSize();
+
+    public void truncate(long byteOffset);
+
+    public long usedSize();
+}

--- a/src/javax/microedition/io/file/FileSystemListener.java
+++ b/src/javax/microedition/io/file/FileSystemListener.java
@@ -1,0 +1,26 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.io.file;
+
+public interface FileSystemListener 
+{
+	public static final int ROOT_ADDED = 1;
+
+	public static final int ROOT_REMOVED = 0;
+
+	public abstract void rootChanged(int state, String rootName);
+}

--- a/src/javax/microedition/io/file/FileSystemRegistry.java
+++ b/src/javax/microedition/io/file/FileSystemRegistry.java
@@ -1,0 +1,28 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.io.file;
+
+import java.util.Enumeration;
+
+public abstract class FileSystemRegistry 
+{
+    public abstract boolean addFileSystemListener(FileSystemListener listener);
+
+    public abstract Enumeration listRoots();
+
+    public abstract boolean removeFileSystemListener(FileSystemListener listener);
+}

--- a/src/javax/microedition/io/file/IllegalModeException.java
+++ b/src/javax/microedition/io/file/IllegalModeException.java
@@ -1,0 +1,24 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/ 
+package javax.microedition.io.file;
+
+public class IllegalModeException extends RuntimeException 
+{
+	public IllegalModeException() {}
+
+	public IllegalModeException(String detailMessage) { System.out.println("IllegalModeException: " + detailMessage); }
+}

--- a/src/javax/microedition/rms/RecordStore.java
+++ b/src/javax/microedition/rms/RecordStore.java
@@ -548,6 +548,7 @@ public class RecordStore
 			//System.out.println("> Next Record ID (idx:"+index+" cnt:"+count+")");
 			if(keepupdated) { rebuild(); }
 			if(index>=count) { throw(new InvalidRecordIDException()); }
+			if(index < 0) return elements[0]; // If an invalid index is received, truncate it to 0.
 			return elements[index];
 		}
 

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -185,7 +185,7 @@ public class Libretro
 									}
 									else
 									{
-										Mobile.getPlatform().pointerReleased(mousey, mousex);
+										Mobile.getPlatform().pointerReleased(-mousey+lcdWidth, mousex);
 									}
 								break;
 
@@ -198,7 +198,7 @@ public class Libretro
 									}
 									else
 									{
-										Mobile.getPlatform().pointerPressed(mousey, mousex);
+										Mobile.getPlatform().pointerPressed(-mousey+lcdWidth, mousex);
 									}
 								break;
 
@@ -211,7 +211,7 @@ public class Libretro
 									}
 									else
 									{
-										Mobile.getPlatform().pointerDragged(mousey, mousex);
+										Mobile.getPlatform().pointerDragged(-mousey+lcdWidth, mousex);
 									}
 								break;
 


### PR DESCRIPTION
Copying the PR message from the previous similarly-named one: More general improvements to the game compatibility, this time by adding some classes not available to them prior and working around a few weird behavior that some games relied on, enabling many to go beyond the boot sequence and even reach near-perfect gameplay now. The screen pointer on the libretro frontend was also fixed, since it wasn't pointing at the correct coordinates when the screen was rotated, which many Touchscreen games require.

But this time, those new implementations and stubs are clean and based off of Java's ME JSR Community Process docs, since many can't be found on the main javadocs pages.