### PR TITLE
Libretro: Disable buttons that can call the built-in menu.

### DIFF
--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -415,12 +415,13 @@ void retro_run(void)
 				}
 			}
 
-			if(joypad[8]+joypad[10]+joypad[11]==3)
+			// This isn't as useful on libretro, and also freezes the frontend if "Exit" is selected
+			/*if(joypad[8]+joypad[10]+joypad[11]==3)
 			{
 				// start+L+R = ESC
 				unsigned char event[5] = { 1, 0,0,0,27 };
 				write(pWrite[1], event, 5);
-			}
+			}*/
 		}
 
 		// grab frame

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -461,7 +461,7 @@ public class Libretro
 			case 93: return Mobile.NOKIA_SOFT2; // ]
 
 			// ESC - Config Menu
-			case 27: config.start();
+			//case 27: config.start(); /* This menu won't be available on the Libretro frontend */
 
 		}
 		return 0;


### PR DESCRIPTION
Related to #138. Calling that menu won't be necessary due to the frontend, and it also has the potential to freeze it if the user selects the "Exit" option.