### PR TITLE
Initial fix for possible negative index, might need something more down the line.

### DIFF
--- a/src/javax/microedition/rms/RecordStore.java
+++ b/src/javax/microedition/rms/RecordStore.java
@@ -441,6 +441,7 @@ public class RecordStore
 		{
 			keepupdated = keepUpdated;
 			index = 0;
+			count = 0;
 
 			this.filter = filter;
 			this.comparator = comparator;
@@ -587,6 +588,7 @@ public class RecordStore
 		{
 			build();
 			if(index >= count) { index = count-1; }
+			if(index < 0) { index = 0; }
 		}
 
 		public void reset()


### PR DESCRIPTION
This one fixes #152, at least partially. Pinball 3D Timeshock boots and saves rms data now... but some blind spots for the index on rms might still be present.