### PR TITLE
Stubbing the rest of JSR 075 (PIM)

### DIFF
--- a/src/javax/microedition/pim/Contact.java
+++ b/src/javax/microedition/pim/Contact.java
@@ -1,0 +1,68 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public interface Contact extends PIMItem 
+{
+    
+	public static final int ADDR = 100;
+	public static final int BIRTHDAY = 101;
+	public static final int CLASS = 102;
+	public static final int EMAIL = 103;
+	public static final int FORMATTED_ADDR = 104;
+	public static final int FORMATTED_NAME = 105;
+	public static final int NAME = 106;
+	public static final int NICKNAME = 107;
+	public static final int NOTE = 108;
+	public static final int ORG = 109;
+	public static final int PHOTO = 110;
+	public static final int PHOTO_URL = 111;
+	public static final int PUBLIC_KEY = 112;
+	public static final int PUBLIC_KEY_STRING = 113;
+	public static final int REVISION = 114;
+	public static final int TEL = 115;
+	public static final int TITLE = 116;
+	public static final int UID = 117;
+	public static final int URL = 118;
+	public static final int ATTR_ASST = 1;
+	public static final int ATTR_AUTO = 2;
+	public static final int ATTR_FAX = 4;
+	public static final int ATTR_HOME = 8;
+	public static final int ATTR_MOBILE = 16;
+	public static final int ATTR_OTHER = 32;
+	public static final int ATTR_PAGER = 64;
+	public static final int ATTR_PREFERRED = 128;
+	public static final int ATTR_SMS = 256;
+	public static final int ATTR_WORK = 512;
+	public static final int ADDR_POBOX = 0;
+	public static final int ADDR_EXTRA = 1;
+	public static final int ADDR_STREET = 2;
+	public static final int ADDR_LOCALITY = 3;
+	public static final int ADDR_REGION = 4;
+	public static final int ADDR_POSTALCODE = 5;
+	public static final int ADDR_COUNTRY = 6;
+	public static final int NAME_FAMILY = 0;
+	public static final int NAME_GIVEN = 1;
+	public static final int NAME_OTHER = 2;
+	public static final int NAME_PREFIX = 3;
+	public static final int NAME_SUFFIX = 4;
+	public static final int CLASS_CONFIDENTIAL = 200;
+	public static final int CLASS_PRIVATE = 201;
+	public static final int CLASS_PUBLIC = 202;
+
+	public int getPreferredIndex(int field) throws IllegalArgumentException, UnsupportedFieldException;
+}

--- a/src/javax/microedition/pim/ContactList.java
+++ b/src/javax/microedition/pim/ContactList.java
@@ -1,0 +1,27 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public interface ContactList extends PIMList 
+{
+
+	public Contact createContact();
+
+	public Contact importContact(Contact contact) throws NullPointerException;
+
+	public void removeContact(Contact contact) throws NullPointerException, SecurityException, PIMException;
+}

--- a/src/javax/microedition/pim/Event.java
+++ b/src/javax/microedition/pim/Event.java
@@ -1,0 +1,38 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public interface Event extends PIMItem 
+{
+
+	public static final int ALARM = 100;
+	public static final int CLASS = 101;
+	public static final int END = 102;
+	public static final int LOCATION = 103;
+	public static final int NOTE = 104;
+	public static final int REVISION = 105;
+	public static final int START = 106;
+	public static final int SUMMARY = 107;
+	public static final int UID = 108;
+	public static final int CLASS_CONFIDENTIAL = 200;
+	public static final int CLASS_PRIVATE = 201;
+	public static final int CLASS_PUBLIC = 202;
+
+	public RepeatRule getRepeat();
+
+	public void setRepeat(RepeatRule value);
+}

--- a/src/javax/microedition/pim/EventList.java
+++ b/src/javax/microedition/pim/EventList.java
@@ -1,0 +1,38 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+import java.util.Enumeration;
+
+public interface EventList extends PIMList 
+{
+	
+	public static final int STARTING = 0;
+	public static final int ENDING = 1;
+	public static final int OCCURRING = 2;
+
+	public Event createEvent();
+
+	public Event importEvent(Event item) throws NullPointerException;
+
+	public void removeEvent(Event item) throws NullPointerException, SecurityException, PIMException;
+
+	public Enumeration items(int searchType, long startDate, long endDate, boolean initialEventOnly)
+	    throws IllegalArgumentException, SecurityException, PIMException;
+
+	public int[] getSupportedRepeatRuleFields(int frequency) throws IllegalArgumentException;
+}

--- a/src/javax/microedition/pim/FieldEmptyException.java
+++ b/src/javax/microedition/pim/FieldEmptyException.java
@@ -24,13 +24,13 @@ public class FieldEmptyException extends RuntimeException
 	public FieldEmptyException() { fieldVal = -1; }
 
 	public FieldEmptyException(String detailMessage) 
-    {
+	{
 		super(detailMessage);
 		fieldVal = -1;
 	}
 
 	public FieldEmptyException(String detailMessage, int field) 
-    {
+	{
 		super(detailMessage);
 		this.fieldVal = field;
 	}

--- a/src/javax/microedition/pim/FieldEmptyException.java
+++ b/src/javax/microedition/pim/FieldEmptyException.java
@@ -1,0 +1,39 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public class FieldEmptyException extends RuntimeException 
+{
+	
+	private final int fieldVal;
+
+	public FieldEmptyException() { fieldVal = -1; }
+
+	public FieldEmptyException(String detailMessage) 
+    {
+		super(detailMessage);
+		fieldVal = -1;
+	}
+
+	public FieldEmptyException(String detailMessage, int field) 
+    {
+		super(detailMessage);
+		this.fieldVal = field;
+	}
+
+	public int getField() { return fieldVal; }
+}

--- a/src/javax/microedition/pim/FieldEmptyException.java
+++ b/src/javax/microedition/pim/FieldEmptyException.java
@@ -19,7 +19,7 @@ package javax.microedition.pim;
 public class FieldEmptyException extends RuntimeException 
 {
 	
-	private final int fieldVal;
+	private int fieldVal;
 
 	public FieldEmptyException() { fieldVal = -1; }
 
@@ -32,7 +32,7 @@ public class FieldEmptyException extends RuntimeException
 	public FieldEmptyException(String detailMessage, int field) 
 	{
 		super(detailMessage);
-		this.fieldVal = field;
+		fieldVal = field;
 	}
 
 	public int getField() { return fieldVal; }

--- a/src/javax/microedition/pim/FieldFullException.java
+++ b/src/javax/microedition/pim/FieldFullException.java
@@ -24,13 +24,13 @@ public class FieldFullException extends RuntimeException
 	public FieldFullException() { fieldVal = -1; }
 
 	public FieldFullException(String detailMessage) 
-    {
+	{
 		super(detailMessage);
 		fieldVal = -1;
 	}
 
 	public FieldFullException(String detailMessage, int field) 
-    {
+	{
 		super(detailMessage);
 		this.fieldVal = field;
 	}

--- a/src/javax/microedition/pim/FieldFullException.java
+++ b/src/javax/microedition/pim/FieldFullException.java
@@ -19,7 +19,7 @@ package javax.microedition.pim;
 public class FieldFullException extends RuntimeException 
 {
     
-	private final int fieldVal;
+	private int fieldVal;
 
 	public FieldFullException() { fieldVal = -1; }
 
@@ -32,7 +32,7 @@ public class FieldFullException extends RuntimeException
 	public FieldFullException(String detailMessage, int field) 
 	{
 		super(detailMessage);
-		this.fieldVal = field;
+		fieldVal = field;
 	}
 
 	public int getField() { return fieldVal; }

--- a/src/javax/microedition/pim/FieldFullException.java
+++ b/src/javax/microedition/pim/FieldFullException.java
@@ -1,0 +1,39 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public class FieldFullException extends RuntimeException 
+{
+    
+	private final int fieldVal;
+
+	public FieldFullException() { fieldVal = -1; }
+
+	public FieldFullException(String detailMessage) 
+    {
+		super(detailMessage);
+		fieldVal = -1;
+	}
+
+	public FieldFullException(String detailMessage, int field) 
+    {
+		super(detailMessage);
+		this.fieldVal = field;
+	}
+
+	public int getField() { return fieldVal; }
+}

--- a/src/javax/microedition/pim/PIM.java
+++ b/src/javax/microedition/pim/PIM.java
@@ -33,7 +33,7 @@ public abstract class PIM
 	protected PIM() { }
 
 	public static PIM getInstance() 
-    {
+	{
 		throw new SecurityException("PIM is stubbed, can't access this device's instance");
 	}
 

--- a/src/javax/microedition/pim/PIM.java
+++ b/src/javax/microedition/pim/PIM.java
@@ -1,0 +1,55 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+public abstract class PIM 
+{
+
+	public static final int CONTACT_LIST = 1;
+	public static final int EVENT_LIST = 2;
+	public static final int TODO_LIST = 3;
+	public static final int READ_ONLY = 1;
+	public static final int WRITE_ONLY = 2;
+	public static final int READ_WRITE = 3;
+
+	protected PIM() { }
+
+	public static PIM getInstance() 
+    {
+		throw new SecurityException("PIM is stubbed, can't access this device's instance");
+	}
+
+	public abstract PIMList openPIMList(int pimListType, int mode) throws SecurityException, 
+        IllegalArgumentException, PIMException;
+
+	public abstract PIMList openPIMList(int pimListType, int mode, String name) throws SecurityException, 
+        IllegalArgumentException, NullPointerException, PIMException;
+
+	public abstract String[] listPIMLists(int pimListType) throws SecurityException, IllegalArgumentException;
+
+	public abstract PIMItem[] fromSerialFormat(InputStream is, String enc) throws NullPointerException, 
+        PIMException, UnsupportedEncodingException;
+
+	public abstract void toSerialFormat(PIMItem item, OutputStream os, String enc, String dataFormat)
+		throws NullPointerException, IllegalArgumentException, PIMException, UnsupportedEncodingException;
+
+	public abstract String[] supportedSerialFormats(int pimListType) throws IllegalArgumentException;
+}

--- a/src/javax/microedition/pim/PIMException.java
+++ b/src/javax/microedition/pim/PIMException.java
@@ -1,0 +1,46 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public class PIMException extends Exception 
+{
+
+	public static final int FEATURE_NOT_SUPPORTED = 0;
+	public static final int GENERAL_ERROR = 1;
+	public static final int LIST_CLOSED = 2;
+	public static final int LIST_NOT_ACCESSIBLE = 3;
+	public static final int MAX_CATEGORIES_EXCEEDED = 4;
+	public static final int UNSUPPORTED_VERSION = 5;
+	public static final int UPDATE_ERROR = 6;
+	private final int reason;
+
+	public PIMException() { reason = GENERAL_ERROR; }
+
+	public PIMException(String detailMessage) 
+    {
+		super(detailMessage);
+		reason = GENERAL_ERROR;
+	}
+
+	public PIMException(String detailMessage, int reason) 
+    {
+		super(detailMessage);
+		this.reason = reason;
+	}
+
+	public int getReason() { return reason; }
+}

--- a/src/javax/microedition/pim/PIMException.java
+++ b/src/javax/microedition/pim/PIMException.java
@@ -31,13 +31,13 @@ public class PIMException extends Exception
 	public PIMException() { reason = GENERAL_ERROR; }
 
 	public PIMException(String detailMessage) 
-    {
+	{
 		super(detailMessage);
 		reason = GENERAL_ERROR;
 	}
 
 	public PIMException(String detailMessage, int reason) 
-    {
+	{
 		super(detailMessage);
 		this.reason = reason;
 	}

--- a/src/javax/microedition/pim/PIMItem.java
+++ b/src/javax/microedition/pim/PIMItem.java
@@ -1,0 +1,109 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public interface PIMItem 
+{
+
+	public static final int BINARY = 0;
+	public static final int BOOLEAN = 1;
+	public static final int DATE = 2;
+	public static final int INT = 3;
+	public static final int STRING = 4;
+	public static final int STRING_ARRAY = 5;
+	public static final int ATTR_NONE = 0;
+	public static final int EXTENDED_FIELD_MIN_VALUE = 16777216;
+	public static final int EXTENDED_ATTRIBUTE_MIN_VALUE = 16777216;
+
+	public PIMList getPIMList();
+
+	public void commit() throws SecurityException, PIMException;
+
+	public boolean isModified();
+
+	public int[] getFields();
+
+	public byte[] getBinary(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addBinary(int field, int attributes, byte[] value, int offset, int length) 
+        throws IllegalArgumentException, NullPointerException, UnsupportedFieldException, FieldFullException;
+
+	public void setBinary(int field, int index, int attributes, byte[] value, int offset, int length)
+        throws IllegalArgumentException, NullPointerException, UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public long getDate(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addDate(int field, int attributes, long value) throws IllegalArgumentException, 
+        UnsupportedFieldException, FieldFullException;
+
+	public void setDate(int field, int index, int attributes, long value) throws IllegalArgumentException, 
+        UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public int getInt(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addInt(int field, int attributes, int value) throws IllegalArgumentException, 
+        UnsupportedFieldException, FieldFullException;
+
+	public void setInt(int field, int index, int attributes, int value) throws IllegalArgumentException, 
+        UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public String getString(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addString(int field, int attributes, String value) throws IllegalArgumentException, 
+        NullPointerException, UnsupportedFieldException, FieldFullException;
+
+	public void setString(int field, int index, int attributes, String value) throws IllegalArgumentException, 
+    NullPointerException, UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public boolean getBoolean(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addBoolean(int field, int attributes, boolean value) throws IllegalArgumentException, 
+        UnsupportedFieldException, FieldFullException;
+
+	public void setBoolean(int field, int index, int attributes, boolean value) throws IllegalArgumentException, 
+        UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public String[] getStringArray(int field, int index) throws IllegalArgumentException, 
+        IndexOutOfBoundsException, UnsupportedFieldException;
+
+	public void addStringArray(int field, int attributes, String[] value) throws IllegalArgumentException, 
+        NullPointerException, UnsupportedFieldException, FieldFullException;
+
+	public void setStringArray(int field, int index, int attributes, String[] value) throws NullPointerException, 
+        IllegalArgumentException, UnsupportedFieldException, IndexOutOfBoundsException;
+
+	public int countValues(int field) throws IllegalArgumentException, UnsupportedFieldException;
+
+	public void removeValue(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public int getAttributes(int field, int index) throws IllegalArgumentException, IndexOutOfBoundsException, 
+        UnsupportedFieldException;
+
+	public void addToCategory(String category) throws NullPointerException, PIMException;
+
+	public void removeFromCategory(String category) throws NullPointerException;
+
+	public String[] getCategories();
+
+	public int maxCategories();
+}

--- a/src/javax/microedition/pim/PIMList.java
+++ b/src/javax/microedition/pim/PIMList.java
@@ -1,0 +1,83 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+import java.util.Enumeration;
+
+public interface PIMList 
+{
+
+	public static final String UNCATEGORIZED = null;
+
+	String getName();
+
+	void close() throws PIMException;
+
+	Enumeration items() throws PIMException, SecurityException;
+
+	Enumeration items(PIMItem matchingItem) throws PIMException, IllegalArgumentException, 
+        NullPointerException, SecurityException;
+
+	Enumeration items(String matchingValue) throws PIMException, NullPointerException, 
+        SecurityException;
+
+	Enumeration itemsByCategory(String category) throws PIMException, SecurityException;
+
+	String[] getCategories() throws PIMException;
+
+	boolean isCategory(String category) throws PIMException, NullPointerException;
+
+	void addCategory(String category) throws PIMException, SecurityException, 
+        NullPointerException;
+
+	void deleteCategory(String category, boolean deleteUnassignedItems) throws PIMException, 
+        SecurityException, NullPointerException;
+
+	void renameCategory(String currentCategory, String newCategory) throws PIMException, 
+        SecurityException, NullPointerException;
+
+	int maxCategories();
+
+	boolean isSupportedField(int field);
+
+	int[] getSupportedFields();
+
+	boolean isSupportedAttribute(int field, int attribute);
+
+	int[] getSupportedAttributes(int field) throws IllegalArgumentException, 
+        UnsupportedFieldException;
+
+	boolean isSupportedArrayElement(int stringArrayField, int arrayElement);
+
+	int[] getSupportedArrayElements(int stringArrayField) throws IllegalArgumentException, 
+        UnsupportedFieldException;
+
+	int getFieldDataType(int field) throws IllegalArgumentException, UnsupportedFieldException;
+
+	String getFieldLabel(int field) throws IllegalArgumentException, 
+        UnsupportedFieldException;
+
+	String getAttributeLabel(int attribute) throws IllegalArgumentException, 
+        UnsupportedFieldException;
+
+	String getArrayElementLabel(int stringArrayField, int arrayElement) 
+        throws IllegalArgumentException, UnsupportedFieldException;
+
+	int maxValues(int field) throws IllegalArgumentException;
+
+	int stringArraySize(int stringArrayField) throws IllegalArgumentException;
+}

--- a/src/javax/microedition/pim/PIMList.java
+++ b/src/javax/microedition/pim/PIMList.java
@@ -23,61 +23,61 @@ public interface PIMList
 
 	public static final String UNCATEGORIZED = null;
 
-	String getName();
+	public String getName();
 
-	void close() throws PIMException;
+	public void close() throws PIMException;
 
-	Enumeration items() throws PIMException, SecurityException;
+	public Enumeration items() throws PIMException, SecurityException;
 
-	Enumeration items(PIMItem matchingItem) throws PIMException, IllegalArgumentException, 
+	public Enumeration items(PIMItem matchingItem) throws PIMException, IllegalArgumentException, 
         NullPointerException, SecurityException;
 
-	Enumeration items(String matchingValue) throws PIMException, NullPointerException, 
+	public Enumeration items(String matchingValue) throws PIMException, NullPointerException, 
         SecurityException;
 
-	Enumeration itemsByCategory(String category) throws PIMException, SecurityException;
+	public Enumeration itemsByCategory(String category) throws PIMException, SecurityException;
 
-	String[] getCategories() throws PIMException;
+	public String[] getCategories() throws PIMException;
 
-	boolean isCategory(String category) throws PIMException, NullPointerException;
+	public boolean isCategory(String category) throws PIMException, NullPointerException;
 
-	void addCategory(String category) throws PIMException, SecurityException, 
+	public void addCategory(String category) throws PIMException, SecurityException, 
         NullPointerException;
 
-	void deleteCategory(String category, boolean deleteUnassignedItems) throws PIMException, 
+	public void deleteCategory(String category, boolean deleteUnassignedItems) throws PIMException, 
         SecurityException, NullPointerException;
 
-	void renameCategory(String currentCategory, String newCategory) throws PIMException, 
+	public void renameCategory(String currentCategory, String newCategory) throws PIMException, 
         SecurityException, NullPointerException;
 
-	int maxCategories();
+	public int maxCategories();
 
-	boolean isSupportedField(int field);
+	public boolean isSupportedField(int field);
 
-	int[] getSupportedFields();
+	public int[] getSupportedFields();
 
-	boolean isSupportedAttribute(int field, int attribute);
+	public boolean isSupportedAttribute(int field, int attribute);
 
-	int[] getSupportedAttributes(int field) throws IllegalArgumentException, 
+	public int[] getSupportedAttributes(int field) throws IllegalArgumentException, 
         UnsupportedFieldException;
 
-	boolean isSupportedArrayElement(int stringArrayField, int arrayElement);
+	public boolean isSupportedArrayElement(int stringArrayField, int arrayElement);
 
-	int[] getSupportedArrayElements(int stringArrayField) throws IllegalArgumentException, 
+	public int[] getSupportedArrayElements(int stringArrayField) throws IllegalArgumentException, 
         UnsupportedFieldException;
 
-	int getFieldDataType(int field) throws IllegalArgumentException, UnsupportedFieldException;
+	public int getFieldDataType(int field) throws IllegalArgumentException, UnsupportedFieldException;
 
-	String getFieldLabel(int field) throws IllegalArgumentException, 
+	public String getFieldLabel(int field) throws IllegalArgumentException, 
         UnsupportedFieldException;
 
-	String getAttributeLabel(int attribute) throws IllegalArgumentException, 
+	public String getAttributeLabel(int attribute) throws IllegalArgumentException, 
         UnsupportedFieldException;
 
-	String getArrayElementLabel(int stringArrayField, int arrayElement) 
+	public String getArrayElementLabel(int stringArrayField, int arrayElement) 
         throws IllegalArgumentException, UnsupportedFieldException;
 
-	int maxValues(int field) throws IllegalArgumentException;
+	public int maxValues(int field) throws IllegalArgumentException;
 
-	int stringArraySize(int stringArrayField) throws IllegalArgumentException;
+	public int stringArraySize(int stringArrayField) throws IllegalArgumentException;
 }

--- a/src/javax/microedition/pim/RepeatRule.java
+++ b/src/javax/microedition/pim/RepeatRule.java
@@ -1,0 +1,91 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+import java.util.Enumeration;
+
+public class RepeatRule 
+{
+
+	public static final int FREQUENCY = 0;
+	public static final int DAY_IN_MONTH = 1;
+	public static final int DAY_IN_WEEK = 2;
+	public static final int DAY_IN_YEAR = 4;
+	public static final int MONTH_IN_YEAR = 8;
+	public static final int WEEK_IN_MONTH = 16;
+	public static final int COUNT = 32;
+	public static final int END = 64;
+	public static final int INTERVAL = 128;
+	public static final int DAILY = 16;
+	public static final int WEEKLY = 17;
+	public static final int MONTHLY = 18;
+	public static final int YEARLY = 19;
+	public static final int FIRST = 1;
+	public static final int SECOND = 2;
+	public static final int THIRD = 4;
+	public static final int FOURTH = 8;
+	public static final int FIFTH = 16;
+	public static final int LAST = 32;
+	public static final int SECONDLAST = 64;
+	public static final int THIRDLAST = 128;
+	public static final int FOURTHLAST = 256;
+	public static final int FIFTHLAST = 512;
+	public static final int SATURDAY = 1024;
+	public static final int FRIDAY = 2048;
+	public static final int THURSDAY = 4096;
+	public static final int WEDNESDAY = 8192;
+	public static final int TUESDAY = 16384;
+	public static final int MONDAY = 32768;
+	public static final int SUNDAY = 65536;
+	public static final int JANUARY = 131072;
+	public static final int FEBRUARY = 262144;
+	public static final int MARCH = 524288;
+	public static final int APRIL = 1048576;
+	public static final int MAY = 2097152;
+	public static final int JUNE = 4194304;
+	public static final int JULY = 8388608;
+	public static final int AUGUST = 16777216;
+	public static final int SEPTEMBER = 33554432;
+	public static final int OCTOBER = 67108864;
+	public static final int NOVEMBER = 134217728;
+	public static final int DECEMBER = 268435456;
+
+	public RepeatRule() { }
+
+	public Enumeration dates(long startDate, long subsetBeginning, long subsetEnding) 
+    {
+		return null;
+	}
+
+	public void addExceptDate(long date) { }
+
+	public void removeExceptDate(long date) { }
+
+	public Enumeration getExceptDates() { return null; }
+
+	public int getInt(int field) { return 0; }
+
+	public void setInt(int field, int value) { }
+
+	public long getDate(int field) { return 0; }
+
+	public void setDate(int field, long value) { }
+
+	public int[] getFields() { return null; }
+
+	public boolean equals(Object obj) { return false; }
+}

--- a/src/javax/microedition/pim/RepeatRule.java
+++ b/src/javax/microedition/pim/RepeatRule.java
@@ -67,7 +67,7 @@ public class RepeatRule
 	public RepeatRule() { }
 
 	public Enumeration dates(long startDate, long subsetBeginning, long subsetEnding) 
-    {
+	{
 		return null;
 	}
 

--- a/src/javax/microedition/pim/ToDo.java
+++ b/src/javax/microedition/pim/ToDo.java
@@ -1,0 +1,34 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public interface ToDo extends PIMItem 
+{
+
+	public static final int CLASS = 100;
+	public static final int COMPLETED = 101;
+	public static final int COMPLETION_DATE = 102;
+	public static final int DUE = 103;
+	public static final int NOTE = 104;
+	public static final int PRIORITY = 105;
+	public static final int REVISION = 106;
+	public static final int SUMMARY = 107;
+	public static final int UID = 108;
+	public static final int CLASS_CONFIDENTIAL = 200;
+	public static final int CLASS_PRIVATE = 201;
+	public static final int CLASS_PUBLIC = 202;
+}

--- a/src/javax/microedition/pim/ToDoList.java
+++ b/src/javax/microedition/pim/ToDoList.java
@@ -21,12 +21,12 @@ import java.util.Enumeration;
 public interface ToDoList extends PIMList 
 {
 
-	ToDo createToDo();
+	public ToDo createToDo();
 
-	ToDo importToDo(ToDo item) throws NullPointerException;
+	public ToDo importToDo(ToDo item) throws NullPointerException;
 
-	void removeToDo(ToDo item) throws NullPointerException, SecurityException, PIMException;
+	public void removeToDo(ToDo item) throws NullPointerException, SecurityException, PIMException;
 
-	Enumeration items(int field, long startDate, long endDate) throws IllegalArgumentException, 
+	public Enumeration items(int field, long startDate, long endDate) throws IllegalArgumentException, 
         SecurityException, PIMException;
 }

--- a/src/javax/microedition/pim/ToDoList.java
+++ b/src/javax/microedition/pim/ToDoList.java
@@ -1,0 +1,32 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+import java.util.Enumeration;
+
+public interface ToDoList extends PIMList 
+{
+
+	ToDo createToDo();
+
+	ToDo importToDo(ToDo item) throws NullPointerException;
+
+	void removeToDo(ToDo item) throws NullPointerException, SecurityException, PIMException;
+
+	Enumeration items(int field, long startDate, long endDate) throws IllegalArgumentException, 
+        SecurityException, PIMException;
+}

--- a/src/javax/microedition/pim/UnsupportedFieldException.java
+++ b/src/javax/microedition/pim/UnsupportedFieldException.java
@@ -19,7 +19,7 @@ package javax.microedition.pim;
 public class UnsupportedFieldException extends RuntimeException 
 {
 
-	private final int fieldVal;
+	private int fieldVal;
 
 	public UnsupportedFieldException() { fieldVal = -1; }
 
@@ -32,7 +32,7 @@ public class UnsupportedFieldException extends RuntimeException
 	public UnsupportedFieldException(String detailMessage, int field) 
     {
 		super(detailMessage);
-		this.fieldVal = field;
+		fieldVal = field;
     }
 
 	public int getField() { return fieldVal; }

--- a/src/javax/microedition/pim/UnsupportedFieldException.java
+++ b/src/javax/microedition/pim/UnsupportedFieldException.java
@@ -1,0 +1,39 @@
+/*
+	This file is part of FreeJ2ME.
+
+	FreeJ2ME is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	FreeJ2ME is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with FreeJ2ME.  If not, see http://www.gnu.org/licenses/
+*/
+package javax.microedition.pim;
+
+public class UnsupportedFieldException extends RuntimeException 
+{
+
+	private final int fieldVal;
+
+	public UnsupportedFieldException() { fieldVal = -1; }
+
+	public UnsupportedFieldException(String detailMessage) 
+    {
+		super(detailMessage);
+		fieldVal = -1;
+	}
+
+	public UnsupportedFieldException(String detailMessage, int field) 
+    {
+		super(detailMessage);
+		this.fieldVal = field;
+	}
+
+	public int getField() { return fieldVal; }
+}

--- a/src/javax/microedition/pim/UnsupportedFieldException.java
+++ b/src/javax/microedition/pim/UnsupportedFieldException.java
@@ -27,13 +27,13 @@ public class UnsupportedFieldException extends RuntimeException
     {
 		super(detailMessage);
 		fieldVal = -1;
-	}
+    }
 
 	public UnsupportedFieldException(String detailMessage, int field) 
     {
 		super(detailMessage);
 		this.fieldVal = field;
-	}
+    }
 
 	public int getField() { return fieldVal; }
 }


### PR DESCRIPTION
JSR 075 is composed of both FileConnect and PIM. FileConnect is being reviewed alongside bluetooth and obex over at #145, and adding even more files to that massive pull request isn't a good idea. Thankfully, PIM has no dependency on FileConnect, so it can be its own PR.

Fixes #155.

Edit: I see, yes i could have separated it into smaller units, but i figured having the whole PIM spec in one PR would be more organized. I'll try shortening the amount of files and changes in the next pull requests.