### PR TITLE
Implement screen rotation on the AWT frontend, and add mouse drag events to both AWT and libretro.

### DIFF
--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -392,6 +392,7 @@ void retro_run(void)
 				joyevent[4] = (touchY) & 0xFF;
 				write(pWrite[1], joyevent, 5);
 				joyevent[0] = 4; // touch up
+				write(pWrite[1], joyevent, 5);
 			}
 		}
 		

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -379,12 +379,10 @@ void retro_run(void)
 			touchY = (int)(((float)(touchY + 0x7FFF)) * ((float)frameHeight / (float)0xFFFE));
 			joymouseAnalog = false;
 			joyevent[0] = 5; // mouse down
-			joyevent[1] = (touchX >> 8) & 0xFF;
-			joyevent[2] = (touchX) & 0xFF;
-			joyevent[3] = (touchY >> 8) & 0xFF;
-			joyevent[4] = (touchY) & 0xFF;
-			write(pWrite[1], joyevent, 5);
-			joyevent[0] = 4; // mouse up
+			joyevent[1] = (joymouseX >> 8) & 0xFF;
+			joyevent[2] = (joymouseX) & 0xFF;
+			joyevent[3] = (joymouseY >> 8) & 0xFF;
+			joyevent[4] = (joymouseY) & 0xFF;
 			write(pWrite[1], joyevent, 5);
 		}
 

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -234,6 +234,23 @@ public class FreeJ2ME
 
 		});
 
+		lcd.addMouseMotionListener(new MouseMotionAdapter() 
+		{
+			public void mouseDragged(MouseEvent e)
+			{
+				int x = (int)((e.getX()-lcd.cx) * lcd.scalex);
+				int y = (int)((e.getY()-lcd.cy) * lcd.scaley);
+
+				if(rotateDisplay)
+				{
+					x = (int)((lcd.ch-(e.getY()-lcd.cy)) * lcd.scaley);
+					y = (int)((e.getX()-lcd.cx) * lcd.scalex);
+				}
+				
+				Mobile.getPlatform().pointerDragged(x, y); 
+			}
+		});
+
 		main.addComponentListener(new ComponentAdapter()
 		{
 			public void componentResized(ComponentEvent e)


### PR DESCRIPTION
Fixes #156.
Edit: Fixes #158 as well.
Edit 2: Also related to #138.
Opted to unify both issues in a same PR because the game i tested for #158 also depends on #156 for screen rotation.

This PR now not only implements rotation on the AWT frontend, but also mouse drag events on it, and on libretro as well.