### PR TITLE
FreeJ2ME: Apply resolutions passed as commandline args.

### DIFF
--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -249,6 +249,16 @@ public class FreeJ2ME
 		if(Mobile.getPlatform().loadJar(jarfile))
 		{
 			config.init();
+
+			/* Allows FreeJ2ME to set the width and height passed as cmd arguments. */
+			if(args.length>=3)
+			{
+				lcdWidth = Integer.parseInt(args[1]);
+				lcdHeight = Integer.parseInt(args[2]);
+				config.settings.put("width",  ""+lcdWidth);
+				config.settings.put("height", ""+lcdHeight);
+			}
+
 			settingsChanged();
 
 			Mobile.getPlatform().runJar();


### PR DESCRIPTION
Previously FreeJ2ME wouldn't apply resolutions passed as arguments because it would init a config file with the default res of 240x320 and update the main app with this default res, completely overriding the arguments received. This commit solves that, and also makes it so that the received args also override the resolution set in the config file, since those arguments still wouldn't apply in case a config file was already saved from a given app that was run with FreeJ2ME previously at a different res.

Fixes #165 