### PR TITLE
Update README.md with clearer build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,51 @@ Development thread:
   https://retropie.org.uk/forum/topic/11441/would-you-like-to-play-nokia-j2me-games-on-retropie/
 
 ----
-**Compilation:**
-```
-> cd freej2me/
-> ant
+**FreeJ2ME Jar Compilation:**
 
-# SDL2 binary compilation
-> cd src/sdl2
-> make
-> make install
-```
-Will create jar files for each frontend. SDL2 jar file needs SDL binary to be compiled. SDL2 can be used to play on Raspberry pi.
+>From the root directory, running the following commands:
+>```
+> > cd freej2me/
+> > ant
+>```
+> Will create three different jar files inside `build/`:
+>
+> `freej2me.jar` -> Standalone AWT jar executable
+> 
+> `freej2me-lr.jar` -> Libretro executable (has to be placed on the frontend's `system/` folder, since it acts as a BIOS for the libretro core and runs J2ME jars)
+>
+>`freej2me-sdl.jar` -> Jar executable meant to be used in conjunction with SDL2
+>
+>Both the Libretro and SDL2 jar files need additional binaries to be compiled before use. Look at the additional steps below if you're going to use one of them.
+
+**Building the SDL2 binary:**
+>
+>To build the SDL2 binary, run the following commands from the root directory:
+> ```
+> # SDL2 binary compilation
+> > cd src/sdl2
+> > make
+> > make install
+> ```
+>
+> SDL2 allows FreeJ2ME to run on a Raspberry Pi.
+
+**Building the Libretro core (Not working on Windows as of yet):**
+>
+>To build the libretro core, run the following commands from the root directory:
+>```
+># libretro core compilation
+> > cd src/libretro
+> > make
+>```
+>This will build `freej2me_libretro.so` on `src/libretro/`, which is the core libretro will use to interface with `freej2me-lr.jar`.
+>
+>Move it to your libretro frontend's `cores/` folder, with freej2me-lr.jar on `system/` and the frontend should be able to load j2me files afterwards.
+>
+>NOTE: The core DOES NOT WORK on containerized/sandboxed environments unless it can call a java runtime that also resides in the same sandbox or container, keep that in mind if you're running a libretro frontend through something like flatpak or snap for example.
 
 ----
-**Usage:**
+**Usage (applies to AWT and SDL):**
 
 Launching the AWT frontend (freej2me.jar) will bring up a filepicker to select the MIDlet to run.
 


### PR DESCRIPTION
Closes #176.

There wasn't any indication on how to build the libretro core. This change adds it and makes all build steps a bit clearer in general.