### PR TITLE
libretro Windows core minor fix

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -100,7 +100,6 @@ else ifeq ($(platform), vita)
    CXXFLAGS += -Wl,-q -Wall -O3
 	STATIC_LINKING = 1
 else
-   CC = gcc
    TARGET := $(TARGET_NAME)_libretro.dll
    SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=$(CORE_DIR)/link.T -Wl,--no-undefined
 endif

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -1095,7 +1095,7 @@ void javaOpen(char *cmd, char **params)
 	/* Try starting the child process. */
 	char cmdWin[PATH_MAX_LENGTH];
 	/* resArg[0], resArg[1], rotateArg, phoneArg, fpsArg, soundArg */
-	sprintf(cmdWin, "java -jar %s", cmd);
+	sprintf(cmdWin, "javaw -jar %s", cmd);
 
 	log_fn(RETRO_LOG_INFO, "Opening: %s \n", cmd);
 	for (int i = 3; i <= 8; i++) /* There are 8 cmd arguments for now */


### PR DESCRIPTION
 - remove console window by using javaw
 - allow use env `CC` to override gcc to use