### PR TITLE
PlatformPlayer: Add support for custom MIDI soundfonts

### DIFF
--- a/src/libretro/freej2me_libretro.h
+++ b/src/libretro/freej2me_libretro.h
@@ -144,7 +144,7 @@ struct retro_core_option_v2_definition core_options[] =
             { "15",   "15 FPS"   },
             { NULL, NULL },
         },
-        "60"
+        "Auto"
     },
     {
         "freej2me_sound",
@@ -159,6 +159,20 @@ struct retro_core_option_v2_definition core_options[] =
             { NULL, NULL },
         },
         "on"
+    },
+    {
+        "freej2me_midifont",
+        "Virtual Phone Settings > MIDI Soundfont",
+        "MIDI Soundfont",
+        "Selects which kind of MIDI soundfont to use. 'Default' uses the soundfont bundled with the system or Java VM, while 'Custom' allows you to place a custom soundfont on '<freej2me-lr.jar folder>/freej2me_system/customMIDI' and use it on J2ME apps to simulate a specific phone or improve MIDI sound quality. WARNING: Big soundfonts greatly increase the emulator's RAM footprint and processing requirements, while smaller ones can actually help it perform better.",
+        "Selects which kind of MIDI soundfont to use. 'Default' uses the soundfont bundled with the system or Java VM, while 'Custom' allows you to place a custom soundfont on '<freej2me-lr.jar folder>/freej2me_system/customMIDI' and use it on J2ME apps to simulate a specific phone or improve MIDI sound quality. WARNING: Big soundfonts greatly increase the emulator's RAM footprint and processing requirements, while smaller ones can actually help it perform better.",
+        "vphone_settings",
+        {
+            { "off", "Default" },
+            { "on",  "Custom" },
+            { NULL, NULL },
+        },
+        "Default"
     },
     {
         "freej2me_pointertype",
@@ -344,7 +358,7 @@ struct retro_core_option_definition core_options_v1 [] =
             { "15",   "15 FPS"   },
             { NULL, NULL },
         },
-        "60"
+        "Auto"
     },
     {
         "freej2me_sound",
@@ -356,6 +370,17 @@ struct retro_core_option_definition core_options_v1 [] =
             { NULL, NULL },
         },
         "on"
+    },
+    {
+        "freej2me_midifont",
+        "MIDI Soundfont",
+        "Selects which kind of MIDI soundfont to use. 'Default' uses the soundfont bundled with the system or Java VM, while 'Custom' allows you to place a custom soundfont on '<freej2me-lr.jar folder>/freej2me_system/customMIDI' and use it on J2ME apps to simulate a specific phone or improve MIDI sound quality. WARNING: Big soundfonts greatly increase the emulator's RAM footprint and processing requirements, while smaller ones can actually help it perform better.",
+        {
+            { "off", "Default" },
+            { "on",  "Custom" },
+            { NULL, NULL },
+        },
+        "Default"
     },
     {
         "freej2me_pointertype",
@@ -469,11 +494,15 @@ static const struct retro_variable vars[] =
     },
     { /* Game FPS limit */
         "freej2me_fps",
-        "Game FPS Limit; 60|30|15|Auto" 
+        "Game FPS Limit; Auto|60|30|15" 
     },
     { /* Virtual Phone Sound */
         "freej2me_sound",
         "Virtual Phone Sound; on|off"
+    },
+    { /* MIDI Soundfont */
+        "freej2me_midifont",
+        "MIDI Soundfont; off|on"
     },
     { /* Pointer Type */
         "freej2me_pointertype",

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -65,14 +65,14 @@ public class Config
 		gc = lcd.getGraphics();
 
 		menu = new ArrayList<String[]>();
-		menu.add(new String[]{"Resume Game", "Display Size", "Sound", "Limit FPS", "Phone", "Rotate", "Exit"}); // 0 - Main Menu
+		menu.add(new String[]{"Resume Game", "Display Size", "Sound", "Limit FPS", "Phone", "Rotate", "MIDI", "Exit"}); // 0 - Main Menu
 		menu.add(new String[]{"96x65","96x96","104x80","128x128","132x176","128x160","176x208","176x220", "208x208", "240x320", "320x240", "240x400", "352x416", "360x640", "640x360" ,"480x800", "800x480"}); // 1 - Size
 		menu.add(new String[]{"Quit", "Main Menu"}); // 2 - Restart Notice
 		menu.add(new String[]{"On", "Off"}); // 3 - sound
 		menu.add(new String[]{"Standard", "Nokia", "Siemens","Motorola"}); // 4 - Phone 
 		menu.add(new String[]{"On", "Off"}); // 5 - rotate 
 		menu.add(new String[]{"Auto", "60 - Fast", "30 - Slow", "15 - Turtle"}); // 6 - FPS
-
+		menu.add(new String[]{"Default", "Custom"});  // 7 - MIDI soundfont
 
 		onChange = new Runnable()
 		{
@@ -111,6 +111,7 @@ public class Config
 				settings.put("phone", "Standard");
 				settings.put("rotate", "off");
 				settings.put("fps", "0");
+				settings.put("soundfont", "Default");
 				saveConfig();
 			}
 		}
@@ -150,6 +151,7 @@ public class Config
 			if(!settings.containsKey("phone")) { settings.put("phone", "Standard"); }
 			if(!settings.containsKey("rotate")) { settings.put("rotate", "off"); }
 			if(!settings.containsKey("fps")) { settings.put("fps", "0"); }
+			if(!settings.containsKey("soundfont")) { settings.put("soundfont", "Default"); }
 
 			int w = Integer.parseInt(settings.get("width"));
 			int h = Integer.parseInt(settings.get("height"));
@@ -319,6 +321,7 @@ public class Config
 					case 3: label = label+": "+settings.get("fps"); break;
 					case 4: label = label+": "+settings.get("phone"); break;
 					case 5: label = label+": "+settings.get("rotate"); break;
+					case 6: label = label+": "+settings.get("soundfont"); break;
 				}
 			}
 			if(i==itemid)
@@ -349,7 +352,8 @@ public class Config
 					case 3: menuid=6; itemid=0; break; // fps
 					case 4: menuid=4; itemid=0; break; // phone
 					case 5: menuid=5; itemid=0; break; // rotate
-					case 6: System.exit(0); break;
+					case 6: menuid=7; itemid=0; break; // MIDI soundfont
+					case 7: System.exit(0); break;
 				}
 			break;
 
@@ -395,6 +399,12 @@ public class Config
 				if(itemid==2) { updateFPS("30"); }
 				if(itemid==3) { updateFPS("15"); }
 				menuid=0; itemid=0;
+			break;
+
+			case 7: // Set MIDI Soundfont to System default or custom file
+				if(itemid==0) { updateSoundfont("Default"); }
+				if(itemid==1) { updateSoundfont("Custom"); }
+				menuid=2; itemid=0;
 			break;
 
 		}
@@ -443,6 +453,14 @@ public class Config
 	{
 		System.out.println("Config: fps "+value);
 		settings.put("fps", value);
+		saveConfig();
+		onChange.run();
+	}
+
+	private void updateSoundfont(String value)
+	{
+		System.out.println("Config: soundfont "+value);
+		settings.put("soundfont", value);
 		saveConfig();
 		onChange.run();
 	}

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -81,9 +81,9 @@ public class FreeJ2ME
 		// Setup Device //
 
 		/* 
-		* If the directory for custom soundfonts doesn't exist, create it, no matter if the user
-		* is going to use it or not.
-		*/
+		 * If the directory for custom soundfonts doesn't exist, create it, no matter if the user
+		 * is going to use it or not.
+		 */
 		try 
 		{
 			if(!PlatformPlayer.soundfontDir.exists()) 
@@ -347,7 +347,8 @@ public class FreeJ2ME
 		if(rotate.equals("off")) { rotateDisplay = false; }
 
 		String midiSoundfont = config.settings.get("soundfont");
-		if(midiSoundfont.equals("Custom")) { PlatformPlayer.customMidi = true; }
+		if(midiSoundfont.equals("Custom"))  { PlatformPlayer.customMidi = true; }
+		if(midiSoundfont.equals("Default")) { PlatformPlayer.customMidi = false; }
 
 		// Create a standard size LCD if not rotated, else invert window's width and height.
 		if(!rotateDisplay) 

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -27,6 +27,8 @@ import java.awt.event.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
+
 import javax.imageio.ImageIO;
 
 public class FreeJ2ME
@@ -77,6 +79,22 @@ public class FreeJ2ME
 		});
 
 		// Setup Device //
+
+		/* 
+		* If the directory for custom soundfonts doesn't exist, create it, no matter if the user
+		* is going to use it or not.
+		*/
+		try 
+		{
+			if(!PlatformPlayer.soundfontDir.exists()) 
+			{ 
+				PlatformPlayer.soundfontDir.mkdirs();
+				File dummyFile = new File(PlatformPlayer.soundfontDir + "/Put your sf2 bank here");
+				dummyFile.createNewFile();
+			}
+		}
+		catch(IOException e) { System.out.println("Failed to create custom midi info file:" + e.getMessage()); }
+		
 
 		lcdWidth = 240;
 		lcdHeight = 320;
@@ -327,6 +345,9 @@ public class FreeJ2ME
 		String rotate = config.settings.get("rotate");
 		if(rotate.equals("on")) { rotateDisplay = true; }
 		if(rotate.equals("off")) { rotateDisplay = false; }
+
+		String midiSoundfont = config.settings.get("soundfont");
+		if(midiSoundfont.equals("Custom")) { PlatformPlayer.customMidi = true; }
 
 		// Create a standard size LCD if not rotated, else invert window's width and height.
 		if(!rotateDisplay) 


### PR DESCRIPTION
Given this is a bit of an experiment, i don't expect it to be merged, but there's no harm in trying since it would be a nice feature to have.

While it has already been closed, this PR would technically close #74... Had some fun with it this weekend and the prospect of having FreeJ2ME be able to effectively "remaster" midi tracks or simulate some phones like the Nokia Series 30 was very interesting.

Turns out it is possible to alter the soundfont used by a JVM's midi synth, and not only is it easy, but it can also be isolated from system drivers, which means users can just put a .sf2 file on the specified folder, enable the option on libretro or AWT menus, and run with it without having to deal with MIDI shenanigans on linux or windows.

Personal testing showed that while you can load pretty much any soundfont in there, the RAM and processing requirements will vary a lot depending on the used soundfont. On one hand you can make MIDI samples sound like they're coming from a Yamaha Tyros 4 if you really want to, but be ready to use 10+ gigs of RAM just to load some games, but on the other you can use small soundfonts and FreeJ2ME will actually get lighter and some games (Asphalt 4) will load slightly faster.

As an example, running Block Breaker 2 Deluxe with TyrolandGS.sf2 (a soundfont that simulates the Tyros 4 + Roland JV-1010) gets me the following usage stats upon reaching the menu:
![FreeJ2ME_TyrolandGS_RAM](https://github.com/hex007/freej2me/assets/52329050/7c278735-e6d3-42a2-9686-18dce9ab8bdb)
