### PR TITLE
Improve audio playback for both wav and midi streams

### DIFF
--- a/src/javax/microedition/media/Manager.java
+++ b/src/javax/microedition/media/Manager.java
@@ -25,12 +25,24 @@ public final class Manager
 {
 
 	public static final String TONE_DEVICE_LOCATOR = "device://tone";
-
+	public static Player midiChannel[] = new Player[36];
+	public static byte midiChannelIndex = 0;
 
 	public static Player createPlayer(InputStream stream, String type) throws IOException, MediaException
 	{
 		//System.out.println("Create Player Stream "+type);
-		return new PlatformPlayer(stream, type);
+		if(type.equalsIgnoreCase("audio/mid") || type.equalsIgnoreCase("audio/midi") || type.equalsIgnoreCase("sp-midi") || type.equalsIgnoreCase("audio/spmidi"))
+		{
+			if(midiChannelIndex >= midiChannel.length) { midiChannelIndex = 0; }
+			if(midiChannel[midiChannelIndex] != null)  { midiChannel[midiChannelIndex].deallocate(); }
+			midiChannel[midiChannelIndex] = new PlatformPlayer(stream, type);
+			midiChannelIndex++;
+			return midiChannel[midiChannelIndex-1];
+		}
+		else 
+		{
+			return new PlatformPlayer(stream, type);
+		}
 	}
 
 	public static Player createPlayer(String locator) throws MediaException

--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -206,8 +206,6 @@ public class PlatformPlayer implements Player
 	{
 		private Sequencer midi;
 
-		private int loops = 0;
-
 		private long tick = 0L;
 
 		public midiPlayer(InputStream stream)
@@ -250,8 +248,8 @@ public class PlatformPlayer implements Player
 
 		public void setLoopCount(int count)
 		{
-			loops = count;
-			midi.setLoopCount(count);
+			if(count < 1) {count = 1;} /* Treat cases where an app might set loops as 0 */
+			midi.setLoopCount(count-1);
 		}
 		public long setMediaTime(long now)
 		{
@@ -283,8 +281,6 @@ public class PlatformPlayer implements Player
 		private int[] wavHeaderData = new int[4];
 		
 		/* Player control variables */
-		private int loops = 0;
-
 		private long time = 0L;
 
 		public wavPlayer(InputStream stream)
@@ -349,8 +345,8 @@ public class PlatformPlayer implements Player
 
 		public void setLoopCount(int count)
 		{
-			loops = count;
-			wavClip.loop(count);
+			if(count < 1) {count = 1;} /* Treat cases where an app might set loops as 0 */
+			wavClip.loop(count-1);
 		}
 
 		public long setMediaTime(long now)

--- a/src/org/recompile/mobile/WavImaAdpcmDecoder.java
+++ b/src/org/recompile/mobile/WavImaAdpcmDecoder.java
@@ -36,16 +36,16 @@ public class WavImaAdpcmDecoder
 	 * are being decoded. So far only seems to happen in Java 8 and on my more limited devices."
 	 *     - @AShiningRay
 	 */
-	private static final int LEFTCHANNEL = 0;
-	private static final int RIGHTCHANNEL = 1;
+	private static final byte LEFTCHANNEL = 0;
+	private static final byte RIGHTCHANNEL = 1;
 
-	private static final int HEADERSIZE = 44;
-	private static final int PCMPREAMBLESIZE = 16;
+	private static final byte HEADERSIZE = 44;
+	private static final byte PCMPREAMBLESIZE = 16;
 
 	private static final int[] prevSample = {0, 0};
 	private static final int[] prevStep = {0, 0};
 	
-	private static final int[] ima_step_index_table = 
+	private static final byte[] ima_step_index_table = 
 	{
 		-1, -1, -1, -1, 2, 4, 6, 8, 
 		-1, -1, -1, -1, 2, 4, 6, 8


### PR DESCRIPTION
Fixes #197 
Fixes #198 

First off, i think it might result in conflicts if #192 is to be merged at some point, so i'll have to look at it later.

Now to the PR itself... this one contains fixes for audio looping on both MIDI and WAV streams, as well as a workaround to ID Software games' tendency to infinitely allocate new MIDI streams. The latter doesn't have a straightforward fix as far as i can tell, since InputStreams are used heavily throughout the audio players, though i'm open to discussions on how to improve this workaround or even do away with it by implementing a better fix.

As a bonus, this PR also comes packed with a few minor cleanups to the ADPCM decoder, as well as threading support for it, to make it a bit lighter at runtime.