### PR TITLE
PlatformPlayer: Only stop media playback if it is running

### DIFF
--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -238,6 +238,7 @@ public class PlatformPlayer implements Player
 
 		public void stop()
 		{
+			if(!isRunning()) { return; }
 			midi.stop();
 			state = Player.PREFETCHED;
 			tick = midi.getTickPosition();
@@ -341,6 +342,7 @@ public class PlatformPlayer implements Player
 
 		public void stop()
 		{
+			if(!isRunning()) { return; }
 			wavClip.stop();
 			time = wavClip.getMicrosecondPosition();
 			state = Player.PREFETCHED;


### PR DESCRIPTION
Fixes #200 

"Orcs and Elves" constantly tries to stop a MIDI stream that isn't even running, and ends up causing a stack overflow on PlatformPlayer. Since it only makes sense to stop streams that are actually running, add a check for cases where they aren't.

Since it has been shown to happen with MIDI streams, it might happen on WAV streams as well, so i'm adding that check for both.