### PR TITLE
PlatformPlayer: Attempt to load audio files with empty contentType

### DIFF
--- a/src/org/recompile/mobile/PlatformPlayer.java
+++ b/src/org/recompile/mobile/PlatformPlayer.java
@@ -256,7 +256,11 @@ public class PlatformPlayer implements Player
 				midi.setSequence(stream);
 				state = Player.PREFETCHED;
 			}
-			catch (Exception e) { System.out.println("Couldn't load MIDI file: " + e.getMessage()); }
+			catch (Exception e) 
+			{ 
+				System.out.println("Couldn't load MIDI file: " + e.getMessage());
+				midi.close();
+			}
 		}
 
 		public void start()


### PR DESCRIPTION
Fixes #202 

Refer to that issue for more in-depth info. This one is rather rare, but there are apps which do indeed pass an audio stream to FreeJ2ME without providing its type, so we have to manually try and load them as one of the supported formats.