### PR TITLE
Accept plain file paths in 

### DIFF
--- a/src/org/recompile/freej2me/Anbu.java
+++ b/src/org/recompile/freej2me/Anbu.java
@@ -111,11 +111,11 @@ public class Anbu
 
 	private static String getFormattedLocation(String loc)
 	{
-		if (loc.startsWith("file://") || loc.startsWith("http://"))
+		if (loc.startsWith("file://") || loc.startsWith("http://") || loc.startsWith("https://"))
 			return loc;
 
 		File file = new File(loc);
-		if(!file.exists() || file.isDirectory())
+		if(!file.isFile())
 		{
 			System.out.println("File not found...");
 			System.exit(0);

--- a/src/org/recompile/freej2me/FreeJ2ME.java
+++ b/src/org/recompile/freej2me/FreeJ2ME.java
@@ -84,7 +84,7 @@ public class FreeJ2ME
 		String jarfile = "";
 		if(args.length>=1)
 		{
-			jarfile = args[0];
+			jarfile = getFormattedLocation(args[0]);
 		}
 		if(args.length>=3)
 		{
@@ -299,6 +299,21 @@ public class FreeJ2ME
 		{
 			System.out.println("Couldn't load jar...");
 		}
+	}
+
+	private static String getFormattedLocation(String loc)
+	{
+		if (loc.startsWith("file://") || loc.startsWith("http://") || loc.startsWith("https://"))
+			return loc;
+
+		File file = new File(loc);
+		if(! file.isFile())
+		{
+			System.out.println("File not found...");
+			System.exit(0);
+		}
+
+		return "file://" + file.getAbsolutePath();
 	}
 
 	private void settingsChanged()


### PR DESCRIPTION
In Abu make a small simplification to getFormattedLocation to use isFile to check if the jar file is a file.
Add https as well as http.

Copy this to FreeJ2ME so it can accept plain file paths on the commandline.