### PR TITLE
libretro: report the real number of controller descriptions

### DIFF
--- a/src/libretro/freej2me_libretro.h
+++ b/src/libretro/freej2me_libretro.h
@@ -26,7 +26,7 @@ static const struct retro_controller_description port_1[] =
 /* No use having more than one input port on this core */
 static const struct retro_controller_info ports[] =
 {
-    { port_1, 16 },
+    { port_1, sizeof(port_1) / sizeof(port_1[0]) },
     { 0 },
 };
 


### PR DESCRIPTION
`ports[]` in `src/libretro/freej2me_libretro.h` declares 16 controller descriptions for `port_1[]`, which contains two:

```c
static const struct retro_controller_description port_1[] =
{
    { "Joypad Auto",       RETRO_DEVICE_JOYPAD },
    { "Joypad Port Empty", RETRO_DEVICE_NONE },
};

static const struct retro_controller_info ports[] =
{
    { port_1, 16 },
    { 0 },
};
```

The frontend iterates `num_types` entries, so it reads 14 `retro_controller_description` structs past the end of the array and dereferences whatever `desc` pointers it finds there. On my machine (Linux aarch64, RetroArch 1.22.2) that is fatal — the log shows the two real entries, then a garbage name, then RetroArch dies with SIGSEGV while still in `SET_CONTROLLER_INFO`, long before a MIDlet is loaded:

```
[INFO] [Environ] SET_CONTROLLER_INFO.
[DEBUG]    Port 1:
[DEBUG]       "Joypad Auto" (1)
[DEBUG]       "Joypad Port Empty" (0)
[DEBUG]       "\xef\x4e\x71\x8b\xa5" (16)
Segmentation fault
```

It is undefined behaviour on every platform; whether it crashes just depends on what happens to sit after the array in the binary, so x86 builds may well have been getting away with it.

The change derives the count from the array itself, so it can't drift again:

```c
{ port_1, sizeof(port_1) / sizeof(port_1[0]) },
```

With that one line the core works end to end here: `freej2me_libretro.so` built for aarch64, `freej2me-lr.jar` in `system/`, and a small MIDlet compiled against the FreeJ2ME classes runs at the expected 240x320 for 900 frames and exits cleanly. Nothing else needed changing to build or run the core on aarch64.