### PR TITLE
Add a libretro buildbot CI recipe

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,88 @@
+# DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
+
+##############################################################################
+################################# BOILERPLATE ################################
+##############################################################################
+
+# Core definitions
+.core-defs:
+  variables:
+    CORENAME: freej2me
+    MAKEFILE: Makefile
+    MAKEFILE_PATH: src/libretro
+
+# Inclusion templates, required for the build to work
+include:
+  ################################## DESKTOPS ################################
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
+  # Windows 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-mingw.yml'
+
+  # Linux 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-x64.yml'
+
+  # Linux 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-i686.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
+  ################################## CELLULAR ################################
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
+# Stages for building
+stages:
+  - build-prepare
+  - build-shared
+  - build-static
+
+##############################################################################
+#################################### STAGES ##################################
+##############################################################################
+#
+################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs
+
+# Linux 64-bit
+libretro-build-linux-x64:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux 32-bit
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
+    - .core-defs
+
+################################### CELLULAR #################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs


### PR DESCRIPTION
FreeJ2ME has no build on the libretro buildbot - on any platform. The reason is mechanical rather than technical: the buildbot only builds what has a `.gitlab-ci.yml` recipe on git.libretro.com, and this repository has never had one.

This adds the standard recipe. The only thing specific to this project is the path:

```yaml
.core-defs:
  variables:
    CORENAME: freej2me
    MAKEFILE: Makefile
    MAKEFILE_PATH: src/libretro
```

Covered: Windows x64/i686 (MinGW), Linux x64/i686/aarch64, webOS. The libretro shim builds standalone - no JDK or ant is involved at build time, so the CI containers need nothing extra; I built it here on aarch64 (`make -C src/libretro`) and it links `freej2me_libretro.so` in a couple of seconds, 131 kB, no warnings worth mentioning.

Left out on purpose:

- **macOS.** The Makefile's `osx` branch still defaults to `ARCHFLAGS = -arch i386 -arch x86_64`, and both osx templates pass `platform: osx`, so the jobs would ask current Xcode for an i386 slice. That needs a small Makefile change first, which felt out of place in a CI-only PR.
- **Android/iOS.** No `jni/Android.mk`, and the iOS branch hardcodes `-arch armv7` with an old deployment target.

One caveat worth stating plainly: this file only takes effect once the repository is mirrored to git.libretro.com, which is an admin action on the libretro side. Happy to open that request once this is in - and note that the core still needs `freej2me-lr.jar` in `system/` plus a JRE at runtime, exactly as the `.info` file already declares.